### PR TITLE
Add resnet50 truncated like the model used in mlcommons submission

### DIFF
--- a/models/.gitignore
+++ b/models/.gitignore
@@ -3,3 +3,4 @@
 /mlcommons_ssd_resnet34_int8.onnx
 /yolov5l_int8.onnx
 /yolov5m_int8.onnx
+/mlcommons_resnet50_v1.5_int8_truncated.onnx

--- a/models/mlcommons_resnet50_v1.5_int8_truncated.onnx.dvc
+++ b/models/mlcommons_resnet50_v1.5_int8_truncated.onnx.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 975076d450e70b42dcb4a137afa7a568
+  size: 25855815
+  path: mlcommons_resnet50_v1.5_int8_truncated.onnx


### PR DESCRIPTION
이 모델은 기존에 포함되어 있던 resnet50 과 같이 입력은 fp32 라서 원본 이미지를 간단한 후처리 후 image를 바로 받을 수 있으면서 mlcommons 제출에 사용된 resnet50 처럼 마지막 Squeeze, DequantizedLinear, ArgMax 가 잘려 있는 모델입니다.

아래 그림에서 왼쪽이 기존 모델의 출력부, 오른쪽 그림이 이 PR이 포함한 모델과 같은 출력부 (그림은 mlcommons의 모델에서 가져왔습니다만 동일 합니다) 입니다.
![image](https://user-images.githubusercontent.com/225941/181655521-36e1d4a8-d810-49e5-8b08-172de16c3a30.png)

이 모델을 이용해서 mlcommons 에서 사용되었던 post processing 코드를 재활용할 수 있습니다.

모델 변경 작업은 Jason 님께서 진행해주셨으며 관련 대화는 https://furiosa-ai.slack.com/archives/C03M6M0DT4Z/p1658374521205629 에서 참고하실 수 있습니다.
