### PR TITLE
Add truncated ssd mobilenet/resnet34

### DIFF
--- a/models/.gitignore
+++ b/models/.gitignore
@@ -4,3 +4,5 @@
 /yolov5l_int8.onnx
 /yolov5m_int8.onnx
 /mlcommons_resnet50_v1.5_int8_truncated.onnx
+/mlcommons_ssd_resnet34_int8.onnx_truncated.onnx
+/mlcommons_ssd_mobilenet_v1_int8.onnx_truncated.onnx

--- a/models/mlcommons_ssd_mobilenet_v1_int8.onnx_truncated.onnx.dvc
+++ b/models/mlcommons_ssd_mobilenet_v1_int8.onnx_truncated.onnx.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 175bc3e1ddaf497f2fc1f43b82c33953
+  size: 6965063
+  path: mlcommons_ssd_mobilenet_v1_int8.onnx_truncated.onnx

--- a/models/mlcommons_ssd_resnet34_int8.onnx_truncated.onnx.dvc
+++ b/models/mlcommons_ssd_resnet34_int8.onnx_truncated.onnx.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 554544429574c93f947c60323ea24b50
+  size: 20154444
+  path: mlcommons_ssd_resnet34_int8.onnx_truncated.onnx


### PR DESCRIPTION
입력부는 fp32, 출력보는 mlcommons 때 썼던 모델과 같이 수정된 모델입니다.

모델에 대한 요청 및 관련 정보 스레드는 아래에서 찾으실 수 있습니다.
https://furiosa-ai.slack.com/archives/C03M6M0DT4Z/p1660809797895899?thread_ts=1658374521.205629&cid=C03M6M0DT4Z

