### PR TITLE
Replace maturin with setuptools-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,5 @@ edition = "2021"
 name = "furiosa_models_native"
 crate-type = ["cdylib"]
 
-# https://maturin.rs/project_layout.html#alternate-python-source-directory-src-layout
-[package.metadata.maturin]
-python-source = "python"
-name = "furiosa.models.furiosa_models_native"
-
 [dependencies]
 pyo3 = { version = "0.16.5", features = ["extension-module"] }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include Cargo.toml
+recursive-include python/furiosa/models *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
-build-backend = "maturin"
+requires = ["setuptools", "wheel", "setuptools-rust"]
 
 [project]
 name = "furiosa-models"
@@ -58,6 +57,7 @@ test = [
     "pytest-asyncio ~= 0.17.2",
 ]
 
+# FIXME: wrong url
 [project.urls]
 Home = "https://furiosa.ai"
 Documentation = "https://github.com/furiosa-ai/furiosa-artifacts"

--- a/python/furiosa/__init__.py
+++ b/python/furiosa/__init__.py
@@ -1,1 +1,0 @@
-"""Furiosa Packages"""

--- a/python/furiosa/models/vision/nonblocking/__init__.py
+++ b/python/furiosa/models/vision/nonblocking/__init__.py
@@ -1,9 +1,10 @@
 from typing import Any
 
-from furiosa.models.utils import load_dvc
-from furiosa.models.vision import resnet50, ssd_mobilenet, ssd_resnet34
-from furiosa.models.vision.yolov5 import large as yolov5l
 from furiosa.registry import Format, Metadata, Publication
+
+from ...utils import load_dvc
+from ...vision import resnet50, ssd_mobilenet, ssd_resnet34
+from ...vision.yolov5 import large as yolov5l
 
 __all__ = [
     "ResNet50",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from setuptools import find_namespace_packages, setup
+from setuptools_rust import Binding, RustExtension
+
+setup(
+    packages=find_namespace_packages(where="python"),
+    package_dir={"": "python"},
+    rust_extensions=[
+        RustExtension(
+            "furiosa.models.furiosa_models_native",
+            path="Cargo.toml",
+            binding=Binding.PyO3,
+            debug=False,
+        )
+    ],
+    # rust extensions are not zip safe, just like C-extensions.
+    zip_safe=False,
+)

--- a/tests/test_sum_as_string.py
+++ b/tests/test_sum_as_string.py
@@ -1,0 +1,6 @@
+# FIXME: This is a temporary test script to check rust binding has imported
+from furiosa.models import sum_as_string
+
+
+def test_one_two():
+    assert sum_as_string(1, 2) == '3'


### PR DESCRIPTION
Fixes #23, Fixes #25

혁준님이 공유주신 `setuptools-rust`로 build-backend를 바꿨습니다. maturin이 저희 사용례를 아직 지원하지 않아서 어쩔수 없지만 furiosa-sdk가 setuptools에서 flit으로 build backend를 바꾼 것을 생각하면 뒤로 가는 기분이라 묘하네요...
제가 `pip install .`, `pip install .[test]`, `pip install --editable .`, `pip install --editable .[test]` 네 가지 경우 모두 테스트를 해 보긴 했는데, 천천히 한번 더 확인해주시면 정말 감사하겠습니다.