### PR TITLE
Follow modified repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install 'furiosa-sdk[models]'
 Or you can build from the source code as following:
 
 ```
-git clone https://github.com/furiosa-ai/furiosa-models-experimental
+git clone https://github.com/furiosa-ai/furiosa-models
 pip install .
 ```
 
@@ -45,5 +45,5 @@ Also, you can learn about [Blocking and Non-blocking APIs](blocking_and_nonblock
 if you want to access the models with Asynchronous (AsyncIO) client library.
 
 ## See Also
-* [Furiosa Models - Github](https://github.com/furiosa-ai/furiosa-models-experimental)
+* [Furiosa Models - Github](https://github.com/furiosa-ai/furiosa-models)
 * [Furiosa SDK Documentation](https://furiosa-ai.github.io/docs/latest/en/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,12 @@
 site_name: Furiosa Models
 site_description: DNN Models optimized for FuriosaAI NPU
-site_url: https://furiosa-ai.github.io/furiosa-models-experimental
+site_url: https://furiosa-ai.github.io/furiosa-models
 
 theme:
   name: material
 
-repo_name: furiosa-ai/furiosa-models-experimental
-repo_url: https://github.com/furiosa-ai/furiosa-models-experimental
+repo_name: furiosa-ai/furiosa-models
+repo_url: https://github.com/furiosa-ai/furiosa-models
 
 nav:
 - Overview: index.md
@@ -19,7 +19,7 @@ nav:
 - blocking_and_nonblocking_api.md
 - "NPU-optimized Postprocessor": native_postprocessor.md
 - Changelog: changelog.md
-- Apache License 2.0: 'https://github.com/furiosa-ai/furiosa-models-experimental/blob/main/LICENSE'
+- Apache License 2.0: 'https://github.com/furiosa-ai/furiosa-models/blob/main/LICENSE'
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
기존의 repository 이름이든 `furiosa-models-experimental` 의 흔적이 남아있어 없앴습니다. 간단한 변경입니다.