### PR TITLE
Retain only necessary python dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,22 +33,13 @@ dependencies = [
 
     "aiofiles ~= 22.1.0",
     "aiohttp ~= 3.8.3",
-    "onnx",
-    "onnxruntime",
-    "opencv-python-headless",
-    "pycocotools",
-    "timm",
-    "torch",
-    "torchvision",
-    "pydantic",
-    # Protobuf major version change issue: https://github.com/furiosa-ai/furiosa-artifacts/issues/23
-    "protobuf < 4.0dev",
-    "pyyaml",
-
-    "segmentation_models_pytorch",
-    "pretrainedmodels",
-    "effdet",
-    "numpy",
+    "opencv-python-headless ~= 4.6",
+    "timm ~= 0.4",
+    "torch ~= 1.13",
+    "torchvision ~= 0.14",
+    "pydantic ~= 1.10",
+    
+    "numpy ~= 1.21",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
이 PR 은 필요한 의존성만 남기고 남은 의존성에 대해서는 최신 릴리즈 버전의 릴리즈 버전으로 고정합니다.