### PR TITLE
Documentation versioning is needed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install -r docs/requirements.txt
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs gh-deploy --force -d v0.8.0-dev


### PR DESCRIPTION
gh-pages 업데이트할 때 지금 처럼 문서를 통째로 업그레이드 하지 않고 versioning 해야 할 것 같습니다. 의도하는 버저닝 구조는 다음과 같습니다. latest는 symbolic link로 가장 최신 문서를 가리키려고 합니다. 또한 릴리즈 전에는 `-dev` suffix를 붙이게 됩니다.

https://furiosa-ai.github.io/furiosa-models/latest
https://furiosa-ai.github.io/furiosa-models/v0.8.0-dev (릴리즈 전)
https://furiosa-ai.github.io/furiosa-models/v0.8.0 (릴리즈 후)

로컬에서는 잘되는 것 같은데 CI 상에서 정확히 동작하는지는 해봐야 알 것 같네요.