### PR TITLE
Add enf, dfg artifacts generated by release 0.8.0

### DIFF
--- a/.ci/task.yaml
+++ b/.ci/task.yaml
@@ -23,7 +23,7 @@ spec:
   params:
     - name: image
       description: The container image to use black in
-      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:221023
+      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:v0.8.0
   steps:
     - name: format
       env:
@@ -73,7 +73,7 @@ spec:
   params:
     - name: image
       description: The container image to use black in
-      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:221023
+      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:v0.8.0
   steps:
     - name: run
       env:
@@ -127,7 +127,7 @@ spec:
   params:
     - name: image
       description: The container image
-      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:221023
+      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:v0.8.0
     - name: modelName
       description: Name of the model to run the regression test
   steps:
@@ -171,7 +171,7 @@ spec:
   params:
     - name: image
       description: The container image
-      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:221023
+      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:v0.8.0
   steps:
     - name: regression-test-report
       image: $(params.image)
@@ -208,7 +208,7 @@ spec:
   params:
     - name: image
       description: The container image
-      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:221023
+      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:v0.8.0
   steps:
     - name: set-dvc-cache
       image: $(params.image)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,16 +16,19 @@ RUN pip3 install --upgrade pip wheel setuptools Cython pytest pycocotools \
 
 RUN echo "deb [arch=amd64] https://internal-archive.furiosa.dev/ubuntu focal restricted" \
         > /etc/apt/sources.list.d/furiosa.list && \
+    echo "deb [arch=amd64] https://internal-archive.furiosa.dev/ubuntu focal-rc restricted" \
+        >> /etc/apt/sources.list.d/furiosa.list && \
     echo "deb [arch=amd64] https://internal-archive.furiosa.dev/ubuntu focal-nightly restricted" \
         >> /etc/apt/sources.list.d/furiosa.list
 
-ARG TOOLCHAIN_VERSION=0.8.0-2+nightly-221023
+ARG TOOLCHAIN_VERSION=0.8.0-2
+ARG ONNXRUNTIME_VERSION=1.12.1-2
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5F03AFA423A751913F249259814F888B20B09A7E
 RUN --mount=type=secret,id=furiosa.conf,dst=/etc/apt/auth.conf.d/furiosa.conf,required \
     APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn \
     apt-get update && \
-    apt-get install -y libonnxruntime furiosa-libhal-warboy \
+    apt-get install -y libonnxruntime=$ONNXRUNTIME_VERSION furiosa-libhal-warboy \
         furiosa-libcompiler=$TOOLCHAIN_VERSION \
         furiosa-libnux-extrinsic=$TOOLCHAIN_VERSION \
         furiosa-libnux=$TOOLCHAIN_VERSION

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.dfg.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 37581fe6b8f3731806f9e66da9db3632
+  size: 26751705
+  path: mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.dfg

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.enf.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 0cde870e60e46341ae780aebc87aa4d4
+  size: 58047268
+  path: mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.enf

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_resnet50_v1.5_int8_warboy_2pe.dfg.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_resnet50_v1.5_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 5bfc9f660ce534d81d83d82a901db850
+  size: 26752019
+  path: mlcommons_resnet50_v1.5_int8_warboy_2pe.dfg

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_resnet50_v1.5_int8_warboy_2pe.enf.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_resnet50_v1.5_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: fc18f851b08c39de8aee01cb65a415ec
+  size: 58047077
+  path: mlcommons_resnet50_v1.5_int8_warboy_2pe.enf

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.dfg.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: d07a4c74d0d86868ed34525bbae3efa4
+  size: 7502815
+  path: mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.dfg

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.enf.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 674e8909b7a4492be853864c81784864
+  size: 17453047
+  path: mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.enf

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.dfg.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 485ec1ef5cf0a3989cb0b2fcd45fd58e
+  size: 7504033
+  path: mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.dfg

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.enf.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 41247457d5f8039ac11cd2dd317985e5
+  size: 17468051
+  path: mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.enf

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.dfg.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 45d4eaf53a15260bb8e136b839ee43bf
+  size: 20435795
+  path: mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.dfg

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.enf.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: d356c1e617b1efef0f2bf36250f6e514
+  size: 25757888
+  path: mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.enf

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_resnet34_int8_warboy_2pe.dfg.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_resnet34_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 496c04e83b509224530158e5135a119f
+  size: 20442974
+  path: mlcommons_ssd_resnet34_int8_warboy_2pe.dfg

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_resnet34_int8_warboy_2pe.enf.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/mlcommons_ssd_resnet34_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 13b2439811fe58ccfaf7fcc69afb50f3
+  size: 27167916
+  path: mlcommons_ssd_resnet34_int8_warboy_2pe.enf

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/yolov5l_int8_warboy_2pe.dfg.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/yolov5l_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 2a7f49b3ba67ebc75c50341633bd962a
+  size: 48718037
+  path: yolov5l_int8_warboy_2pe.dfg

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/yolov5l_int8_warboy_2pe.enf.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/yolov5l_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: e4b513702c10576677b551f3fb9d80b1
+  size: 73329898
+  path: yolov5l_int8_warboy_2pe.enf

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/yolov5m_int8_warboy_2pe.dfg.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/yolov5m_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 6e4991d6e707a8cb504b2fd1a0e54a89
+  size: 22416625
+  path: yolov5m_int8_warboy_2pe.dfg

--- a/python/furiosa/models/data/generated/0.8.0_d9f0d7728/yolov5m_int8_warboy_2pe.enf.dvc
+++ b/python/furiosa/models/data/generated/0.8.0_d9f0d7728/yolov5m_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 89e6cc95e1754d2888420d4df46f95f7
+  size: 53698544
+  path: yolov5m_int8_warboy_2pe.enf


### PR DESCRIPTION
npu-tools 는 v0.8.0 artifact가 생성되어 있습니다. 관련해서는 아래에서 진행 살펴보실 수 있습니다. 이 PR은 0.8.0 릴리즈로 생성한 enf, dfg 를 포함합니다. docker, CI 등 업데이트 하며 onnx가 1.13이 nightly 에 올라온 상황이기 때문에 onnx 버전을 명시적으로 지정했습니다.

https://github.com/furiosa-ai/sdk-release/issues/28 