### PR TITLE
Fix mlperf-postprocess dependency with revision specified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 [[package]]
 name = "mlperf-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/furiosa-ai/mlperf-postprocess?branch=main#37403c9c9e9da05dc83928c8626d77c2d7e49aeb"
+source = "git+https://github.com/furiosa-ai/mlperf-postprocess?rev=3c42797#3c42797caa429949f9579573338f78cc0828dca3"
 dependencies = [
  "cbindgen",
  "cpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 itertools = "0.10.3"
-mlperf-postprocess = { git = "https://github.com/furiosa-ai/mlperf-postprocess", branch = "main" }
+mlperf-postprocess = { git = "https://github.com/furiosa-ai/mlperf-postprocess", rev = "3c42797" }
 numpy = "0.16"
 pyo3 = { version = "0.16.6", features = ["extension-module"] }


### PR DESCRIPTION
### Problem
* mlperf-postprocess dependency가 main branch를 바라보고 있어서, 해당 레포지토리에 breaking change가 발생하면 models 빌드가 깨집니다. 

### Solution
* mlperf-postprocess revision을 고정합니다.

### Testing
* 기존 CI의 build test를 통과하면 됩니다.