### PR TITLE
Report regression test result with comment

### DIFF
--- a/.ci/apply.sh
+++ b/.ci/apply.sh
@@ -29,5 +29,8 @@ tkn hub install task git-clone --namespace $NAMESPACE \
 tkn hub install task github-set-status --namespace $NAMESPACE \
     || tkn hub reinstall task github-set-status --namespace $NAMESPACE
 
+tkn hub install task github-add-comment --namespace $NAMESPACE \
+    || tkn hub reinstall task github-add-comment --namespace $NAMESPACE
+
 # Apply all files in cwd
 kubectl apply --namespace $NAMESPACE --filename .

--- a/.ci/label-trigger.yaml
+++ b/.ci/label-trigger.yaml
@@ -287,6 +287,10 @@ spec:
       value: https://github.com/$(params.repo_full_name)/pull/$(params.prNumber)
     - name: COMMENT_OR_FILE
       value: $(params.reportFileName)
+    - name: GITHUB_TOKEN_SECRET_NAME
+      value: "github-credential"
+    - name: GITHUB_TOKEN_SECRET_KEY
+      value: "password"
     runAfter:
       - regression-test-report
 

--- a/.ci/label-trigger.yaml
+++ b/.ci/label-trigger.yaml
@@ -81,6 +81,8 @@ spec:
         taskRunSpecs:
           - pipelineTaskName: regression-test-with-npu
             taskPodTemplate:
+              nodeSelector:
+                alpha.furiosa.ai/npu.rev: A0
               tolerations:
               - key: "npu"
                 operator: "Exists"

--- a/.ci/label-trigger.yaml
+++ b/.ci/label-trigger.yaml
@@ -161,6 +161,9 @@ spec:
       default: "1"
     - name: modelName
       description: Name of the model to run the regression test
+    - name: reportFileName
+      description: Name of the file to save the report data
+      default: "report.txt"
  
   workspaces:
     - name: source
@@ -262,11 +265,28 @@ spec:
   - name: regression-test-report
     taskRef:
       name: regression-test-report
+    params:
+    - name: reportFileName
+      value: $(params.reportFileName)
     workspaces:
       - name: source
         workspace: source
     runAfter:
       - regression-test-with-npu
+
+  - name: github-add-comment
+    taskRef:
+      name: github-add-comment
+    workspaces:
+      - name: comment-file
+        workspace: source
+    params:
+    - name: REQUEST_URL
+      value: https://github.com/$(params.repo_full_name)/pull/$(params.prNumber)
+    - name: COMMENT_OR_FILE
+      value: $(params.reportFileName)
+    runAfter:
+      - regression-test-report
 
   finally:
   - name: set-status-success

--- a/.ci/task.yaml
+++ b/.ci/task.yaml
@@ -202,6 +202,9 @@ spec:
     - name: image
       description: The container image
       default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/furiosa-models:v0.8.0
+    - name: reportFileName
+      description: Name of the file to save the report data
+      default: report.txt
   steps:
     - name: regression-test-report
       image: $(params.image)
@@ -210,7 +213,7 @@ spec:
         pip install --quiet pytest-benchmark
 
         cd /workspace/source
-        py.test-benchmark compare
+        py.test-benchmark compare | tee $(workspaces.source.path)/$(params.reportFileName)
 
       resources:
         requests:

--- a/.ci/task.yaml
+++ b/.ci/task.yaml
@@ -214,7 +214,8 @@ spec:
 
         cd /workspace/source
 
-        echo "\`\`\`" > $(workspaces.source.path)/$(params.reportFileName)
+        git log -n1 --format="%C(auto) %h %s" > $(workspaces.source.path)/$(params.reportFileName)
+        echo "\`\`\`" >> $(workspaces.source.path)/$(params.reportFileName)
         py.test-benchmark compare >> $(workspaces.source.path)/$(params.reportFileName)
         echo "\`\`\`" >> $(workspaces.source.path)/$(params.reportFileName)
 

--- a/.ci/task.yaml
+++ b/.ci/task.yaml
@@ -213,7 +213,10 @@ spec:
         pip install --quiet pytest-benchmark
 
         cd /workspace/source
-        py.test-benchmark compare | tee $(workspaces.source.path)/$(params.reportFileName)
+
+        echo "\`\`\`" > $(workspaces.source.path)/$(params.reportFileName)
+        py.test-benchmark compare >> $(workspaces.source.path)/$(params.reportFileName)
+        echo "\`\`\`" >> $(workspaces.source.path)/$(params.reportFileName)
 
       resources:
         requests:


### PR DESCRIPTION
### Problem
* https://github.com/furiosa-ai/furiosa-models/pull/74#issuecomment-1294019409 에서 제안된, `추후에 여유가 생기면 regression report를 github comment로 posting 하는 기능 까지 넣으면 완벽해질 것 같습니다` 의견을 반영합니다. 

### Solution
* regression test 성공하면 결과를 tekton task [`github-add-comment`](https://hub.tekton.dev/tekton/task/github-add-comment) 활용해서 댓글로 작성합니다.
* 그 외에 warboy-a0 를 할당받도록 CI를 변경하였습니다. b0 지원은 별도 이슈로 생성하겠습니다.

### Testing
* 눈으로 확인