### PR TITLE
Faster boot up

### DIFF
--- a/furiosa/models/client/api.py
+++ b/furiosa/models/client/api.py
@@ -3,8 +3,6 @@ from typing import Callable, List, Optional, Sequence, Type
 
 from tqdm import tqdm
 
-from furiosa.runtime import session
-
 from .. import vision
 from ..types import Model
 from ..utils import get_field_default
@@ -103,6 +101,8 @@ def decorate_result(
 
 
 def run_inferences(model_cls: Type[Model], input_paths: Sequence[str], postprocess: Optional[str]):
+    from furiosa.runtime import session
+
     warning = """WARN: the benchmark results may depend on the number of input samples,
 sizes of the images, and a machine where this benchmark is running."""
     postprocess = postprocess and postprocess.lower()

--- a/furiosa/models/vision/__init__.py
+++ b/furiosa/models/vision/__init__.py
@@ -1,6 +1,24 @@
-from ..vision.resnet50 import ResNet50
-from ..vision.ssd_mobilenet import SSDMobileNet
-from ..vision.ssd_resnet34 import SSDResNet34
-from ..vision.yolov5 import YOLOv5l, YOLOv5m
+from typing import Any, List
 
 __all__ = ["ResNet50", "SSDMobileNet", "SSDResNet34", "YOLOv5l", "YOLOv5m"]
+
+_class_modules = {
+    "ResNet50": ".resnet50",
+    "SSDMobileNet": ".ssd_mobilenet",
+    "SSDResNet34": ".ssd_resnet34",
+    "YOLOv5l": ".yolov5",
+    "YOLOv5m": ".yolov5",
+}
+
+
+def __getattr__(name: str) -> Any:
+    import importlib
+
+    module = importlib.import_module(_class_modules.get(name, "." + name), __name__)
+    cls = getattr(module, name)
+    globals()[name] = cls  # so that __getattr__ won't be called again
+    return cls
+
+
+def __dir__() -> List[str]:
+    return __all__


### PR DESCRIPTION
fixes #108
@senokay 님이 작성해주신 module level lazy loading을 적용하고, furiosa.runtime.session 임포트 하는 것이 느려서 해당 모듈을 사용하는 함수에서 import 하게 바꾸었습니다.
`furiosa-models` 명령어의 help와 list가 조금 빨라졌습니다.

Before
```
time furiosa-models --help

real    0m1.606s
user    0m1.773s
sys     0m4.673s
```

```
time furiosa-models list

real    0m1.689s
user    0m1.837s
sys     0m4.485s
```


After
```
time furiosa-models --help

real    0m0.375s
user    0m1.129s
sys     0m5.502s
```

```
time furiosa-models list

real    0m1.197s
user    0m1.537s
sys     0m3.906s
```
