### PR TITLE
Fix Inference net time

### DIFF
--- a/furiosa/models/client/api.py
+++ b/furiosa/models/client/api.py
@@ -135,4 +135,4 @@ sizes of the images, and a machine where this benchmark is running."""
         decorate_result(all_done - initial_time, queries, "Preprocess -> Inference -> Postprocess")
     )
     print(decorate_result(all_done - after_preprocess, queries, "Inference -> Postprocess"))
-    print(decorate_result(all_done - after_npu, queries, "Inference", newline=False))
+    print(decorate_result(after_npu - after_preprocess, queries, "Inference", newline=False))


### PR DESCRIPTION
Inference 헤딩으로 표시되는 시간이 Inference가 아니라 postprocess에 걸린 시간을 표시하고 있었습니다.