### PR TITLE
Add efficientnetb0 model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ SHELL=/bin/bash -o pipefail
 
 .PHONY: check-docker-tag toolchain lint test unit_tests examples regression-test-all \
 regression-test-resnet50 regression-test-ssd-mobilenet \
-regression-test-ssd-resnet34 regression-test-yolov5 doc docker-build docker-push
+regression-test-ssd-resnet34 regression-test-yolov5 doc docker-build docker-push \
+regression-test-efficientnet-b0
 
 check-docker-tag:
 ifndef DOCKER_TAG
@@ -44,6 +45,9 @@ regression-test-yolov5:
 	pytest -s ./tests/bench/test_unit_yolov5m.py && \
 	pytest -s ./tests/bench/test_yolov5l.py && \
 	pytest -s ./tests/bench/test_yolov5m.py
+
+regression-test-efficientnet-b0:
+	pytest -s ./tests/bench/test_efficientnet_b0.py
 
 doc:
 	mkdocs build

--- a/docs/examples/efficientnet_b0.py
+++ b/docs/examples/efficientnet_b0.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from furiosa.models.vision import EfficientNetB0
+from furiosa.runtime import session
+
+image = "tests/assets/cat.jpg"
+
+effnetb0 = EfficientNetB0.load()
+with session.create(effnetb0) as sess:
+    inputs, _ = effnetb0.preprocess(image)
+    outputs = sess.run(inputs).numpy()
+    effnetb0.postprocess(outputs)

--- a/furiosa/models/data/.gitignore
+++ b/furiosa/models/data/.gitignore
@@ -2,3 +2,4 @@
 *.onnx
 *.dfg
 *.enf
+/efficientnet_b0.calib_data.yaml

--- a/furiosa/models/data/efficientnet_b0.calib_data.yaml.dvc
+++ b/furiosa/models/data/efficientnet_b0.calib_data.yaml.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: ecd632d9c47ce839a477157085a1f4e2
+  size: 21137
+  path: efficientnet_b0.calib_data.yaml

--- a/furiosa/models/data/efficientnet_b0.onnx.dvc
+++ b/furiosa/models/data/efficientnet_b0.onnx.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: eeed3bfa53af0f21ac335f6253205332
+  size: 21156473
+  path: efficientnet_b0.onnx

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/efficientnet_b0_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/efficientnet_b0_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 876b7ba8f10900df18aa49a4d84c00f1
+  size: 6673606
+  path: efficientnet_b0_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/efficientnet_b0_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/efficientnet_b0_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 6091461f1e48120ffbbb42a1d4a031ab
+  size: 22182336
+  path: efficientnet_b0_warboy_2pe.enf

--- a/furiosa/models/vision/__init__.py
+++ b/furiosa/models/vision/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any, List
 
-__all__ = ["ResNet50", "SSDMobileNet", "SSDResNet34", "YOLOv5l", "YOLOv5m"]
+__all__ = ["ResNet50", "SSDMobileNet", "SSDResNet34", "YOLOv5l", "YOLOv5m", "EfficientNetB0"]
 
 _class_modules = {
     "ResNet50": ".resnet50",
@@ -8,6 +8,7 @@ _class_modules = {
     "SSDResNet34": ".ssd_resnet34",
     "YOLOv5l": ".yolov5",
     "YOLOv5m": ".yolov5",
+    "EfficientNetB0": ".efficientnet_b0",
 }
 
 

--- a/furiosa/models/vision/efficientnet_b0/__init__.py
+++ b/furiosa/models/vision/efficientnet_b0/__init__.py
@@ -1,0 +1,105 @@
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Sequence, Tuple, Type, Union
+
+from PIL import Image
+import cv2
+import numpy as np
+import numpy.typing as npt
+
+from furiosa.registry.model import Format, Metadata, Publication
+
+from .. import native
+from ...errors import ArtifactNotFound
+from ...types import ImageClassificationModel, Platform, PostProcessor, PreProcessor
+from ...utils import EXT_DFG, EXT_ENF, EXT_ONNX, get_field_default
+from ..common.datasets import imagenet1k
+from ..preprocess import center_crop, resize_with_aspect_ratio
+
+CLASSES: List[str] = imagenet1k.ImageNet1k_CLASSES
+
+IMAGENET_DEFAULT_MEAN = np.array((0.485, 0.456, 0.406), dtype=np.float32)[:, np.newaxis, np.newaxis]
+IMAGENET_DEFAULT_STD = np.array((0.229, 0.224, 0.225), dtype=np.float32)[:, np.newaxis, np.newaxis]
+
+# https://github.com/pytorch/vision/blob/7ba97196757229552cede54639be75e3a0a9959f/torchvision/transforms/functional.py#L386-L392
+def resize(image: Image.Image, size: int, resample: Image.Resampling) -> Image.Image:
+    """Resize `image` so that a smaller edge of the resulting image will be matched to `size`."""
+    # https://github.com/pytorch/vision/blob/0b6b8d42e95a208df85033a46fc7984c74301b35/torchvision/transforms/functional.py#L463
+    # https://github.com/pytorch/vision/blob/0b6b8d42e95a208df85033a46fc7984c74301b35/torchvision/transforms/functional.py#L363-L383
+    width, height = image.size
+    if width <= height:
+        new_width = size
+        new_height = int(size * height / width)
+    else:
+        new_width = int(size * width / height)
+        new_height = size
+
+    image = image.resize((new_width, new_height), resample=resample)
+    return image
+
+
+# https://github.com/pytorch/vision/blob/7ba97196757229552cede54639be75e3a0a9959f/torchvision/transforms/functional.py#L551
+def center_crop(image: Image.Image, cropped_height: int, cropped_width: int) -> Image.Image:
+    """Centrally crop `image` into cropped_width x cropped_height."""
+    width, height = image.size
+
+    # https://github.com/pytorch/vision/blob/7ba97196757229552cede54639be75e3a0a9959f/torchvision/transforms/functional.py#L587-L588
+    top = int(round((height - cropped_height) / 2))
+    left = int(round((width - cropped_width) / 2))
+
+    # https://github.com/pytorch/vision/blob/7ba97196757229552cede54639be75e3a0a9959f/torchvision/transforms/functional_pil.py#L237
+    image = image.crop((left, top, left + cropped_width, top + cropped_height))
+    return image
+
+
+class EfficientNetB0PreProcessor(PreProcessor):
+    @staticmethod
+    def __call__(image: Path) -> Tuple[np.ndarray, None]:
+        """Read and preprocess an image located at image_path."""
+
+        image = Image.open(Path(image)).convert("RGB")
+
+        scale_size = int(math.floor(224 / 0.875))
+        image = resize(image, scale_size, resample=Image.Resampling.BICUBIC)
+
+        image = center_crop(image, 224, 224)
+
+        data = np.asarray(image, dtype=np.float32)
+        data = np.transpose(data, axes=(2, 0, 1))
+        data /= 255
+
+        data -= IMAGENET_DEFAULT_MEAN
+        data /= IMAGENET_DEFAULT_STD
+
+        return data[np.newaxis, ...], None
+
+
+class EfficientNetB0PostProcessor(PostProcessor):
+    def __call__(self, model_outputs: Sequence[npt.ArrayLike], contexts: Any = None) -> str:
+        return CLASSES[int(np.argsort(model_outputs[0], axis=1)[:, ::-1][0, 0])]
+
+
+class EfficientNetB0(ImageClassificationModel):
+    """EfficientNet B0 model"""
+
+    @staticmethod
+    def get_artifact_name():
+        return "efficientnet_b0"
+
+    @classmethod
+    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = True, *args, **kwargs):
+        return cls(
+            name="EfficientNetB0",
+            source=artifacts[EXT_ONNX],
+            dfg=None,
+            enf=None,
+            format=Format.ONNX,
+            family="EfficientNet",
+            version="1.0.2",
+            metadata=Metadata(
+                description="EfficientNetB0 ImageNet-1K",
+                publication=Publication(url="https://arxiv.org/abs/1905.11946"),
+            ),
+            preprocessor=EfficientNetB0PreProcessor(),
+            postprocessor=EfficientNetB0PostProcessor(),
+        )

--- a/furiosa/models/vision/efficientnet_b0/__init__.py
+++ b/furiosa/models/vision/efficientnet_b0/__init__.py
@@ -9,7 +9,7 @@ import numpy.typing as npt
 from furiosa.registry.model import Format, Metadata, Publication
 
 from ...types import ImageClassificationModel, PostProcessor, PreProcessor
-from ...utils import EXT_ONNX
+from ...utils import EXT_DFG, EXT_ENF, EXT_ONNX
 from ..common.datasets import imagenet1k
 from ..preprocess import center_crop
 
@@ -88,8 +88,8 @@ class EfficientNetB0(ImageClassificationModel):
         return cls(
             name="EfficientNetB0",
             source=artifacts[EXT_ONNX],
-            dfg=None,
-            enf=None,
+            dfg=artifacts[EXT_DFG],
+            enf=artifacts[EXT_ENF],
             format=Format.ONNX,
             family="EfficientNet",
             version="1.0.2",

--- a/furiosa/models/vision/efficientnet_b0/__init__.py
+++ b/furiosa/models/vision/efficientnet_b0/__init__.py
@@ -84,7 +84,7 @@ class EfficientNetB0(ImageClassificationModel):
         return "efficientnet_b0"
 
     @classmethod
-    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = True, *args, **kwargs):
+    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = False, *args, **kwargs):
         return cls(
             name="EfficientNetB0",
             source=artifacts[EXT_ONNX],

--- a/furiosa/models/vision/efficientnet_b0/__init__.py
+++ b/furiosa/models/vision/efficientnet_b0/__init__.py
@@ -1,20 +1,17 @@
 import math
 from pathlib import Path
-from typing import Any, Dict, List, Sequence, Tuple, Type, Union
+from typing import Any, Dict, List, Sequence, Tuple
 
 from PIL import Image
-import cv2
 import numpy as np
 import numpy.typing as npt
 
 from furiosa.registry.model import Format, Metadata, Publication
 
-from .. import native
-from ...errors import ArtifactNotFound
-from ...types import ImageClassificationModel, Platform, PostProcessor, PreProcessor
-from ...utils import EXT_DFG, EXT_ENF, EXT_ONNX, get_field_default
+from ...types import ImageClassificationModel, PostProcessor, PreProcessor
+from ...utils import EXT_ONNX
 from ..common.datasets import imagenet1k
-from ..preprocess import center_crop, resize_with_aspect_ratio
+from ..preprocess import center_crop
 
 CLASSES: List[str] = imagenet1k.ImageNet1k_CLASSES
 

--- a/furiosa/models/vision/resnet50/__init__.py
+++ b/furiosa/models/vision/resnet50/__init__.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 class ResNet50PreProcessor(PreProcessor):
     @staticmethod
-    def __call__(image: Union[str, npt.ArrayLike]) -> Tuple[np.array, None]:
+    def __call__(image: Union[str, npt.ArrayLike]) -> Tuple[np.ndarray, None]:
         """Convert an input image to a model input tensor
 
         Args:

--- a/tests/bench/test_efficientnet_b0.py
+++ b/tests/bench/test_efficientnet_b0.py
@@ -37,7 +37,7 @@ def test_mlcommons_efficientnetb0_accuracy(benchmark):
 
     def workload(image, answer):
         global correct_predictions, incorrect_predictions
-        image = model.preprocess(image)
+        image, _ = model.preprocess(image)
         output = sess.run(image).numpy()
         output = model.postprocess(output)
 

--- a/tests/bench/test_efficientnet_b0.py
+++ b/tests/bench/test_efficientnet_b0.py
@@ -2,8 +2,6 @@ import os
 from pathlib import Path
 from typing import List
 
-from PIL import Image
-import numpy as np
 import tqdm
 
 from furiosa.models.vision import EfficientNetB0

--- a/tests/bench/test_efficientnet_b0.py
+++ b/tests/bench/test_efficientnet_b0.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+from typing import List
+
+from PIL import Image
+import numpy as np
+import tqdm
+
+from furiosa.models.vision import EfficientNetB0
+from furiosa.models.vision.common.datasets import imagenet1k
+from furiosa.runtime import session
+
+EXPECTED_ACCURACY = 16.104
+CLASSES: List[str] = imagenet1k.ImageNet1k_CLASSES
+
+
+def test_mlcommons_efficientnetb0_accuracy(benchmark):
+    imagenet_val_images = Path(os.environ.get('IMAGENET_VAL_IMAGES', 'tests/data/imagenet/val'))
+    imagenet_val_labels = Path(
+        os.environ.get('IMAGENET_VAL_LABELS', 'tests/data/imagenet/aux/val.txt')
+    )
+
+    model = EfficientNetB0.load()
+
+    image_paths = list(imagenet_val_images.glob("*.[Jj][Pp][Ee][Gg]"))
+    with open(imagenet_val_labels, encoding="ascii") as file:
+        image_filename_to_label = {
+            image_filename: int(label) for image_filename, label in (line.split() for line in file)
+        }
+
+    image_src_iter = iter(tqdm.tqdm(image_paths))
+    num_images = len(image_paths)
+    global correct_predictions, incorrect_predictions
+    correct_predictions, incorrect_predictions = 0, 0
+
+    def read_image():
+        image_src = next(image_src_iter)
+        return (str(image_src), CLASSES[image_filename_to_label[image_src.name]]), {}
+
+    def workload(image, answer):
+        global correct_predictions, incorrect_predictions
+        image = model.preprocess(image)
+        output = sess.run(image).numpy()
+        output = model.postprocess(output)
+
+        if output == answer:
+            correct_predictions += 1
+        else:
+            incorrect_predictions += 1
+
+    sess = session.create(model)
+    benchmark.pedantic(workload, setup=read_image, rounds=num_images)
+    sess.close()
+
+    total_predictions = correct_predictions + incorrect_predictions
+    accuracy = 100.0 * correct_predictions / total_predictions
+    print("accuracy :", accuracy, "% (", correct_predictions, "/", total_predictions, ")")
+    assert accuracy == EXPECTED_ACCURACY, "Accuracy check failed"

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -63,3 +63,10 @@ def test_yolov5_medium():
         YOLOv5m.load(),
         DATA_DIRECTORY_BASE / "yolov5m_int8.onnx.dvc",
     )
+
+
+def test_efficientnet_b0():
+    sanity_check_for_dvc_file(
+        EfficientNetB0.load(),
+        DATA_DIRECTORY_BASE / "efficientnet_b0.onnx.dvc",
+    )


### PR DESCRIPTION
## Changes

- Deploy an initial model implementation for efficienent-b0, source from [rwightman/gen-efficientnet-pytorch](https://github.com/rwightman/gen-efficientnet-pytorch).
- Exported the pytorch model to onnx as follows:
```
import torch
import onnx
from tempfile import NamedTemporaryFile
import furiosa.optimizer.frontend.onnx

torch_model = torch.hub.load(
    "rwightman/gen-efficientnet-pytorch", "efficientnet_b0", pretrained=True, trust_repo=True
)
torch_model = torch_model.eval()
with NamedTemporaryFile(suffix=".onnx") as file:
    torch.onnx.export(
        torch_model, torch.randn(1, 3, 224, 224), file, opset_version=13
    )
    onnx_model = onnx.load_model(file.name)

onnx.checker.check_model(onnx_model, full_check=True)
optimized_onnx_model = furiosa.optimizer.frontend.onnx.optimize_model(onnx_model)
onnx.checker.check_model(optimized_onnx_model, full_check=True)
optimized_onnx_model = optimized_onnx_model.SerializeToString()
```
- Accuracy: 16.104% (original f32 model: 77.698%)