### PR TITLE
Change model zoo target to warboy-b0-2pe

### DIFF
--- a/.ci/furiosa-models-ci/test.yaml
+++ b/.ci/furiosa-models-ci/test.yaml
@@ -85,7 +85,7 @@ spec:
         TOOLCHAIN_VERSION=$(apt-cache policy furiosa-libcompiler | grep Installed | awk '{print $2}')
         apt-get update && apt-get install -y furiosa-libhal-sim=$TOOLCHAIN_VERSION
 
-        NPU_GLOBAL_CONFIG_PATH=warboy-2pe make examples
+        NPU_GLOBAL_CONFIG_PATH=warboy-b0-2pe make examples
 
       resources:
         requests:

--- a/.ci/furiosa-models-regression-test/label-trigger.yaml
+++ b/.ci/furiosa-models-regression-test/label-trigger.yaml
@@ -82,7 +82,7 @@ spec:
           - pipelineTaskName: regression-test-with-npu
             taskPodTemplate:
               nodeSelector:
-                alpha.furiosa.ai/npu.rev: A0
+                alpha.furiosa.ai/npu.rev: B0
               tolerations:
               - key: "npu"
                 operator: "Exists"

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ ifndef DOCKER_TAG
 endif
 
 toolchain:
-	env ONNXRUNTIME_VERSION=1.12.1-2 sh -c 'apt-get install -y --allow-downgrades libonnxruntime=$$ONNXRUNTIME_VERSION'
-	env TOOLCHAIN_VERSION=0.8.0-2 sh -c 'apt-get install -y --allow-downgrades furiosa-libcompiler=$$TOOLCHAIN_VERSION furiosa-libnux-extrinsic=$$TOOLCHAIN_VERSION furiosa-libnux=$$TOOLCHAIN_VERSION'
-	env LIBHAL_VERSION=0.9.0-2 sh -c 'apt-get install -y --allow-downgrades furiosa-libhal-warboy=$$LIBHAL_VERSION'
+	env ONNXRUNTIME_VERSION=1.13.1-2 sh -c 'apt-get install -y --allow-downgrades libonnxruntime=$$ONNXRUNTIME_VERSION'
+	env TOOLCHAIN_VERSION=0.9.0-2+nightly-230125 sh -c 'apt-get install -y --allow-downgrades furiosa-libcompiler=$$TOOLCHAIN_VERSION furiosa-libnux-extrinsic=$$TOOLCHAIN_VERSION furiosa-libnux=$$TOOLCHAIN_VERSION'
+	env LIBHAL_VERSION=0.10.0-2 sh -c 'apt-get install -y --allow-downgrades furiosa-libhal-warboy=$$LIBHAL_VERSION'
 
 lint:
 	isort --diff --check .

--- a/furiosa/models/data/enf_generator.sh
+++ b/furiosa/models/data/enf_generator.sh
@@ -29,7 +29,7 @@ function compile() {
   else
     echo " ... (Running)"
 
-    COMPILE_CMD="furiosa compile --target-npu warboy-2pe --target-ir ${FORMAT} $ONNX_PATH -o ${OUTPUT_PATH}"
+    COMPILE_CMD="furiosa compile --target-npu warboy-b0-2pe --target-ir ${FORMAT} $ONNX_PATH -o ${OUTPUT_PATH}"
 
     # Try to find the format-specific compiler config
     IR_COMPILER_CONFIG=$MODEL_DIR/${FILENAME}.${FORMAT}.yaml

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 37581fe6b8f3731806f9e66da9db3632
+  size: 26751705
+  path: mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 9363bbad314e792f14eb68366bf817c0
+  size: 57013106
+  path: mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_resnet50_v1.5_int8_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_resnet50_v1.5_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 5bfc9f660ce534d81d83d82a901db850
+  size: 26752019
+  path: mlcommons_resnet50_v1.5_int8_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_resnet50_v1.5_int8_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_resnet50_v1.5_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: d8f7b4911f71f9676d33e9b407fdb84e
+  size: 57012745
+  path: mlcommons_resnet50_v1.5_int8_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: d07a4c74d0d86868ed34525bbae3efa4
+  size: 7502815
+  path: mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 5de53598d2fdd480fd4c82ae3382c709
+  size: 17271233
+  path: mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: e964c7ccc2a38fdbe7dfc9e99280efe1
+  size: 7504204
+  path: mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: caf1750ccde7f32ed27eb0539b664814
+  size: 17286335
+  path: mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 45d4eaf53a15260bb8e136b839ee43bf
+  size: 20435795
+  path: mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 0d2338b8736f9b6892faae8b91e2a942
+  size: 25246243
+  path: mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_resnet34_int8_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_resnet34_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: caac55141c920a590f3171ef8420fe2e
+  size: 20437775
+  path: mlcommons_ssd_resnet34_int8_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_resnet34_int8_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/mlcommons_ssd_resnet34_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 866fb4b4c9a469767ef957d33e29d0cc
+  size: 25261615
+  path: mlcommons_ssd_resnet34_int8_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/yolov5l_int8_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/yolov5l_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 2a7f49b3ba67ebc75c50341633bd962a
+  size: 48718037
+  path: yolov5l_int8_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/yolov5l_int8_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/yolov5l_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 5676d0593e593b4c2ab19b98d7e6a0b1
+  size: 68593382
+  path: yolov5l_int8_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/yolov5m_int8_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/yolov5m_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 6e4991d6e707a8cb504b2fd1a0e54a89
+  size: 22416625
+  path: yolov5m_int8_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/yolov5m_int8_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/yolov5m_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: bee829753f98ac6f081225592cdcecce
+  size: 49510408
+  path: yolov5m_int8_warboy_2pe.enf

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -1,2 +1,0 @@
-def test_hello_world():
-    print("Hello, world!")


### PR DESCRIPTION
## Changes

- update `NPU_GLOBAL_CONFIG_PATH=warboy-b0-2pe` for npu-sim used in CI.
- update warboy rev as (warboy) B0 for regression test CI.
- update `enf_generator.sh` to compile for warboy-b0-2pe target.