### PR TITLE
Add Model Zoo release guide (as developers' manual)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ and they can run even on CPU and GPU as well.
 * [v0.8.0](https://furiosa-ai.github.io/furiosa-models/v0.8.0/changelog/) - 2022-11-10
 
 ## Online Documentation
-If you are new, you can start from [Getting Started](https://furiosa-ai.github.io/furiosa-models/v0.8.0/getting_started/).
+If you are new, you can start from [Getting Started](https://furiosa-ai.github.io/furiosa-models/latest/getting_started/).
 You can also find the latest online documents, 
 including programming guides, API references, and examples from the followings:
 
 * [Furiosa Models - Latest Documentation](https://furiosa-ai.github.io/furiosa-models/latest/)
-* [Model object](https://furiosa-ai.github.io/furiosa-models/v0.8.0/model_object/)
-* [Model List](https://furiosa-ai.github.io/furiosa-models/v0.8.0/#model_list)
-* [Command Tool](https://furiosa-ai.github.io/furiosa-models/v0.8.0/command_tool/)
+* [Model object](https://furiosa-ai.github.io/furiosa-models/latest/model_object/)
+* [Model List](https://furiosa-ai.github.io/furiosa-models/latest/#model_list)
+* [Command Tool](https://furiosa-ai.github.io/furiosa-models/latest/command_tool/)
 * [Furiosa SDK - Tutorial and Code Examples](https://furiosa-ai.github.io/docs/latest/en/software/tutorials.html)
 
 
@@ -29,11 +29,11 @@ you can find details about loading a model, their input and output tensors, pre/
 
 | Model                                                                                    | Task                 | Size | Accuracy                   |
 |------------------------------------------------------------------------------------------| -------------------- | ---- |----------------------------|
-| [ResNet50](https://furiosa-ai.github.io/furiosa-models/v0.8.0/models/resnet50_v1.5/)     | Image Classification | 25M  | 76.002% (ImageNet1K-val)   |
-| [SSDMobileNet](https://furiosa-ai.github.io/furiosa-models/v0.8.0/models/ssd_mobilenet/) | Object Detection     | 7.2M | mAP 0.228 (COCO 2017-val)  |
-| [SSDResNet34](https://furiosa-ai.github.io/furiosa-models/v0.8.0/models/ssd_resnet34/)   | Object Detection     | 20M  | mAP 0.220 (COCO 2017-val)  |
-| [YOLOv5M](https://furiosa-ai.github.io/furiosa-models/v0.8.0/models/yolov5m/)            | Object Detection     | 21M  | mAP 0.280 (Bdd100k-val)\*  |
-| [YOLOv5L](https://furiosa-ai.github.io/furiosa-models/v0.8.0/models/yolov5l/)            | Object Detection     | 46M  | mAP 0.295 (Bdd100k-val)\*  |
+| [ResNet50](https://furiosa-ai.github.io/furiosa-models/latest/models/resnet50_v1.5/)     | Image Classification | 25M  | 76.002% (ImageNet1K-val)   |
+| [SSDMobileNet](https://furiosa-ai.github.io/furiosa-models/latest/models/ssd_mobilenet/) | Object Detection     | 7.2M | mAP 0.228 (COCO 2017-val)  |
+| [SSDResNet34](https://furiosa-ai.github.io/furiosa-models/latest/models/ssd_resnet34/)   | Object Detection     | 20M  | mAP 0.220 (COCO 2017-val)  |
+| [YOLOv5M](https://furiosa-ai.github.io/furiosa-models/latest/models/yolov5m/)            | Object Detection     | 21M  | mAP 0.280 (Bdd100k-val)\*  |
+| [YOLOv5L](https://furiosa-ai.github.io/furiosa-models/latest/models/yolov5l/)            | Object Detection     | 46M  | mAP 0.295 (Bdd100k-val)\*  |
 
 _\*: The accuracy of the yolov5 f32 model trained with bdd100k-val dataset, is mAP 0.295 (for yolov5m) and mAP 0.316 (for yolov5l)._
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,43 @@
+# Developer's guide
+
+This documentation is for developers who want to contribute to Furiosa Models.
+
+## Release guide
+
+### Select the appropriate commit
+
+First, you need to select the proper release candidate commit to release.
+That revision *must pass* all CI tests and be polished.
+
+### Create a dedicated release branch
+
+Create a release branch named `branch-<release version w/o v prefix>` from that commit.
+
+### Set the version
+
+Furiosa Models' main branch is for developers, so it set to `<next-release-version>.dev0`.
+The version information is located in `./furiosa/models/__init__.py`. Please set it with the appropriate one.
+
+### Alter absolute links in documentation
+
+Since `README.md` can appear in many places, including GitHub, the rendered documentation, and the index page of PyPI, there are a few absolute URL links (e.g., `[Getting Started](https://furiosa-ai.github.io/furiosa-models/v0.8.0/getting_started/)`).
+Please change it to appropriate links with the proper version.
+
+### Create release tag
+
+Create a git tag when you publish a release to keep track of revisions in your releases.
+You can create and push a git tag with the following commands.
+
+```shell
+git tag <release version>  # e.g. git tag v0.8.2
+git push --tags <appropriate remote>  # e.g. git push --tags upstream
+```
+
+### Test building wheels
+
+We're using `flit` as our packaging tool, so please test that you can generate a proper wheel using the `flit build` command before releasing.
+You may want to install `flit` first, please install it with `pip install flit`.
+
+## Publish to PyPI
+
+Now you can publish the package with `flit publish` command. :tada:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -4,40 +4,22 @@ This documentation is for developers who want to contribute to Furiosa Models.
 
 ## Release guide
 
-### Select the appropriate commit
+### Preparing for Release
 
-First, you need to select the proper release candidate commit to release.
-That revision *must pass* all CI tests and be polished.
+- [ ] Select a correct release tag to mark the release: `x.y.z`
+- [ ] Update the code in the `main` branch to reflect the next development version.
+    - [ ] `__version__` field in `furiosa/models/__init__.py`
+- [ ] Create a dedicated release branch on github for the new tag.
 
-### Create a dedicated release branch
+### Pre-Release Tasks
 
-Create a release branch named `branch-<release version w/o v prefix>` from that commit.
+Before releasing the new version, ensure that the following tasks are completed:
 
-### Set the version
+- [ ] Update the code in the release branch to the appropriate version.
+- [ ] Generate a rendered documentation for the new release.
+- [ ] Write a changelog that describes the changes made in the new release.
+- [ ] Test the building of wheels by `flit build` to ensure the release is functional.
 
-Furiosa Models' main branch is for developers, so it set to `<next-release-version>.dev0`.
-The version information is located in `./furiosa/models/__init__.py`. Please set it with the appropriate one.
+### Releasing the New Version
 
-### Alter absolute links in documentation
-
-Since `README.md` can appear in many places, including GitHub, the rendered documentation, and the index page of PyPI, there are a few absolute URL links (e.g., `[Getting Started](https://furiosa-ai.github.io/furiosa-models/v0.8.0/getting_started/)`).
-Please change it to appropriate links with the proper version.
-
-### Create release tag
-
-Create a git tag when you publish a release to keep track of revisions in your releases.
-You can create and push a git tag with the following commands.
-
-```shell
-git tag <release version>  # e.g. git tag v0.8.2
-git push --tags <appropriate remote>  # e.g. git push --tags upstream
-```
-
-### Test building wheels
-
-We're using `flit` as our packaging tool, so please test that you can generate a proper wheel using the `flit build` command before releasing.
-You may want to install `flit` first, please install it with `pip install flit`.
-
-### Publish to PyPI
-
-Now you can publish the package with `flit publish` command. 🎉
+- [ ] Publish the package to PyPI with `flit publish` command. 🎉

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -38,6 +38,6 @@ git push --tags <appropriate remote>  # e.g. git push --tags upstream
 We're using `flit` as our packaging tool, so please test that you can generate a proper wheel using the `flit build` command before releasing.
 You may want to install `flit` first, please install it with `pip install flit`.
 
-## Publish to PyPI
+### Publish to PyPI
 
-Now you can publish the package with `flit publish` command. :tada:
+Now you can publish the package with `flit publish` command. 🎉

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - models/yolov5m.md
     - models/yolov5l.md
 - Changelog: changelog.md
+- Developer's guide: developer.md
 - Apache License 2.0: 'https://github.com/furiosa-ai/furiosa-models/blob/main/LICENSE'
 
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ nav:
     - models/yolov5m.md
     - models/yolov5l.md
 - Changelog: changelog.md
-- Developer's guide: developer.md
+- Developer's guide: developers-guide.md
 - Apache License 2.0: 'https://github.com/furiosa-ai/furiosa-models/blob/main/LICENSE'
 
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,8 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
-
+  - pymdownx.tasklist:
+      custom_checkbox: true
 
 plugins:
 - search


### PR DESCRIPTION
Fixes #128 
Rendered page:
https://furiosa-ai.github.io/furiosa-models/PR-129/developers-guide/

I cancelled the CI because this PR is related to documentations only.