### PR TITLE
Add initial implementation for efficientnet-v2-s model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL=/bin/bash -o pipefail
 .PHONY: check-docker-tag toolchain lint test unit_tests examples regression-test-all \
 regression-test-resnet50 regression-test-ssd-mobilenet \
 regression-test-ssd-resnet34 regression-test-yolov5 doc docker-build docker-push \
-regression-test-efficientnet-b0
+regression-test-efficientnet-b0 regression-test-efficientnet-v2-s
 
 check-docker-tag:
 ifndef DOCKER_TAG
@@ -48,6 +48,9 @@ regression-test-yolov5:
 
 regression-test-efficientnet-b0:
 	pytest -s ./tests/bench/test_efficientnet_b0.py
+
+regression-test-efficientnet-v2-s:
+	pytest -s ./tests/bench/test_efficientnet_v2_s.py
 
 doc:
 	mkdocs build

--- a/docs/examples/efficientnet_b0.py
+++ b/docs/examples/efficientnet_b0.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from furiosa.models.vision import EfficientNetB0
 from furiosa.runtime import session
 

--- a/docs/examples/efficientnet_v2_s.py
+++ b/docs/examples/efficientnet_v2_s.py
@@ -1,0 +1,10 @@
+from furiosa.models.vision import EfficientNetV2s
+from furiosa.runtime import session
+
+image = "tests/assets/cat.jpg"
+
+effnetv2s = EfficientNetV2s.load()
+with session.create(effnetv2s) as sess:
+    inputs, _ = effnetv2s.preprocess(image)
+    outputs = sess.run(inputs).numpy()
+    effnetv2s.postprocess(outputs)

--- a/furiosa/models/data/.gitignore
+++ b/furiosa/models/data/.gitignore
@@ -3,3 +3,4 @@
 *.dfg
 *.enf
 /efficientnet_b0.calib_data.yaml
+/efficientnet_v2_s.calib_data.yaml

--- a/furiosa/models/data/efficientnet_v2_s.calib_data.yaml.dvc
+++ b/furiosa/models/data/efficientnet_v2_s.calib_data.yaml.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 8667254dc7b188b167f3692b4f07d450
+  size: 54084
+  path: efficientnet_v2_s.calib_data.yaml

--- a/furiosa/models/data/efficientnet_v2_s.onnx.dvc
+++ b/furiosa/models/data/efficientnet_v2_s.onnx.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 3c4a606d3d885fb836dd2ee0b2f8dd30
+  size: 85754175
+  path: efficientnet_v2_s.onnx

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/efficientnet_v2_s_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/efficientnet_v2_s_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: d294e09afd0d867e0a4547517a8ab779
+  size: 26389478
+  path: efficientnet_v2_s_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0-dev_05955c9b4/efficientnet_v2_s_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0-dev_05955c9b4/efficientnet_v2_s_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 54cce98ccd8c317b6ff934c5d631cdb0
+  size: 67395963
+  path: efficientnet_v2_s_warboy_2pe.enf

--- a/furiosa/models/vision/__init__.py
+++ b/furiosa/models/vision/__init__.py
@@ -1,6 +1,14 @@
 from typing import Any, List
 
-__all__ = ["ResNet50", "SSDMobileNet", "SSDResNet34", "YOLOv5l", "YOLOv5m", "EfficientNetB0"]
+__all__ = [
+    "ResNet50",
+    "SSDMobileNet",
+    "SSDResNet34",
+    "YOLOv5l",
+    "YOLOv5m",
+    "EfficientNetB0",
+    "EfficientNetV2s",
+]
 
 _class_modules = {
     "ResNet50": ".resnet50",
@@ -9,6 +17,7 @@ _class_modules = {
     "YOLOv5l": ".yolov5",
     "YOLOv5m": ".yolov5",
     "EfficientNetB0": ".efficientnet_b0",
+    "EfficientNetV2s": ".efficientnet_v2_s",
 }
 
 

--- a/furiosa/models/vision/efficientnet_v2_s/__init__.py
+++ b/furiosa/models/vision/efficientnet_v2_s/__init__.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from typing import Any, Dict, List, Sequence, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+from furiosa.registry.model import Format, Metadata, Publication
+
+from ...types import ImageClassificationModel, PostProcessor, PreProcessor
+from ...utils import EXT_DFG, EXT_ENF, EXT_ONNX
+from ..common.datasets import imagenet1k
+
+CLASSES: List[str] = imagenet1k.ImageNet1k_CLASSES
+
+
+class EfficientNetV2sPreProcessor(PreProcessor):
+    @staticmethod
+    def __call__(image: Path) -> Tuple[np.ndarray, None]:
+        """Read and preprocess an image located at image_path."""
+        pass
+
+
+class EfficientNetV2sPostProcessor(PostProcessor):
+    def __call__(self, model_outputs: Sequence[npt.ArrayLike], contexts: Any = None) -> str:
+        pass
+
+
+class EfficientNetV2s(ImageClassificationModel):
+    """EfficientNetV2-s model"""
+
+    @staticmethod
+    def get_artifact_name():
+        return "efficientnet_v2_s"
+
+    @classmethod
+    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = False, *args, **kwargs):
+        return cls(
+            name="EfficientNetV2s",
+            source=artifacts[EXT_ONNX],
+            dfg=artifacts[EXT_DFG],
+            enf=artifacts[EXT_ENF],
+            format=Format.ONNX,
+            family="EfficientNetV2",
+            version="s",
+            metadata=Metadata(
+                description="EfficientNetV2s ImageNet-1K",
+                publication=Publication(url="https://arxiv.org/abs/2104.00298"),
+            ),
+            preprocessor=EfficientNetV2sPreProcessor(),
+            postprocessor=EfficientNetV2sPostProcessor(),
+        )

--- a/furiosa/models/vision/efficientnet_v2_s/__init__.py
+++ b/furiosa/models/vision/efficientnet_v2_s/__init__.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any, Dict, List, Sequence, Tuple
 
+from PIL import Image, ImageOps
 import numpy as np
 import numpy.typing as npt
 
@@ -11,18 +12,67 @@ from ...utils import EXT_DFG, EXT_ENF, EXT_ONNX
 from ..common.datasets import imagenet1k
 
 CLASSES: List[str] = imagenet1k.ImageNet1k_CLASSES
+INPUT_SIZE = 384
+
+
+def resize(image: Image.Image, size: int, interpolation: Image.Resampling) -> Image.Image:
+    width, height = image.size
+    short, long = (width, height) if width <= height else (height, width)
+    requested_new_short = size
+
+    new_short, new_long = requested_new_short, int(requested_new_short * long / short)
+    new_width, new_height = (new_short, new_long) if width <= height else (new_long, new_short)
+    return image.resize((new_width, new_height), interpolation)
+
+
+def center_crop(image: Image.Image, output_size: int) -> Image.Image:
+    image_width, image_height = image.size
+    crop_height, crop_width = output_size, output_size
+
+    if crop_width > image_width or crop_height > image_height:
+        padding_ltrb = (
+            (crop_width - image_width) // 2 if crop_width > image_width else 0,
+            (crop_height - image_height) // 2 if crop_height > image_height else 0,
+            (crop_width - image_width + 1) // 2 if crop_width > image_width else 0,
+            (crop_height - image_height + 1) // 2 if crop_height > image_height else 0,
+        )
+        image = ImageOps.expand(image, padding_ltrb, fill=(0, 0, 0))
+        image_width, image_height = image.size
+        if crop_width == image_width and crop_height == image_height:
+            return image
+
+    crop_top = int(round((image_height - crop_height) / 2.0))
+    crop_left = int(round((image_width - crop_width) / 2.0))
+    return image.crop((crop_left, crop_top, crop_left + crop_width, crop_top + crop_height))
+
+
+def normalize(image: Image.Image) -> np.ndarray:
+    image -= np.asarray((0.485, 0.456, 0.406)).reshape(-1, 1, 1)
+    image /= np.asarray((0.229, 0.224, 0.225)).reshape(-1, 1, 1)
+    return image
 
 
 class EfficientNetV2sPreProcessor(PreProcessor):
     @staticmethod
     def __call__(image: Path) -> Tuple[np.ndarray, None]:
         """Read and preprocess an image located at image_path."""
-        pass
+        image = Image.open(image).convert("RGB")
+
+        image = resize(image, INPUT_SIZE, Image.Resampling.BILINEAR)
+        image = center_crop(image, INPUT_SIZE)
+
+        image = np.ascontiguousarray(image)
+        image = np.transpose(image, (2, 0, 1))
+
+        image = image.astype(np.float32) / 255
+
+        data = normalize(image)
+        return data[np.newaxis, ...], None
 
 
 class EfficientNetV2sPostProcessor(PostProcessor):
     def __call__(self, model_outputs: Sequence[npt.ArrayLike], contexts: Any = None) -> str:
-        pass
+        return CLASSES[int(np.argsort(model_outputs[0], axis=1)[:, ::-1][0, 0])]
 
 
 class EfficientNetV2s(ImageClassificationModel):

--- a/tests/bench/test_efficientnet_v2_s.py
+++ b/tests/bench/test_efficientnet_v2_s.py
@@ -4,21 +4,21 @@ from typing import List
 
 import tqdm
 
-from furiosa.models.vision import EfficientNetB0
+from furiosa.models.vision import EfficientNetV2s
 from furiosa.models.vision.common.datasets import imagenet1k
 from furiosa.runtime import session
 
-EXPECTED_ACCURACY = 16.104
+EXPECTED_ACCURACY = 75.208
 CLASSES: List[str] = imagenet1k.ImageNet1k_CLASSES
 
 
-def test_efficientnetb0_accuracy(benchmark):
+def test_efficientnetv2s_accuracy(benchmark):
     imagenet_val_images = Path(os.environ.get('IMAGENET_VAL_IMAGES', 'tests/data/imagenet/val'))
     imagenet_val_labels = Path(
         os.environ.get('IMAGENET_VAL_LABELS', 'tests/data/imagenet/aux/val.txt')
     )
 
-    model = EfficientNetB0.load()
+    model = EfficientNetV2s.load()
 
     image_paths = list(imagenet_val_images.glob("*.[Jj][Pp][Ee][Gg]"))
     with open(imagenet_val_labels, encoding="ascii") as file:

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -70,3 +70,10 @@ def test_efficientnet_b0():
         EfficientNetB0.load(),
         DATA_DIRECTORY_BASE / "efficientnet_b0.onnx.dvc",
     )
+
+
+def test_efficientnet_v2_s():
+    sanity_check_for_dvc_file(
+        EfficientNetV2s.load(),
+        DATA_DIRECTORY_BASE / "efficientnet_v2_s.onnx.dvc",
+    )


### PR DESCRIPTION
## Changes

Deploy an initial model implementation for efficienent-v2-s, source from [pytorch efficientnet_v2_s](https://pytorch.org/vision/main/models/generated/torchvision.models.efficientnet_v2_s.html).

- accuracy: 75.208% (original f32 model: 84.228%)

```python
import torch
import onnx
from tempfile import NamedTemporaryFile
import furiosa.optimizer.frontend.onnx

torch_model = torch.hub.load(
    "pytorch/vision:v0.14.0", "efficientnet_v2_s", weights="DEFAULT", skip_validation=True, force_reload=True
)
torch_model = torch_model.eval()
with NamedTemporaryFile(suffix=".onnx") as file:
    torch.onnx.export(
        torch_model, torch.randn(1, 3, 384, 384), file, opset_version=13
    )
    onnx_model = onnx.load_model(file.name)

onnx.shape_inference.infer_shapes(onnx_model, check_type=True, strict_mode=True)
onnx.checker.check_model(onnx_model)

optimized_onnx_model = furiosa.optimizer.frontend.onnx.optimize_model(onnx_model)
onnx.checker.check_model(optimized_onnx_model, full_check=True)
optimized_onnx_model = optimized_onnx_model.SerializeToString()
```
