### PR TITLE
Decide proper use_native, add missing postprocessor map

### DIFF
--- a/furiosa/models/client/api.py
+++ b/furiosa/models/client/api.py
@@ -4,7 +4,7 @@ from typing import Callable, List, Optional, Sequence, Type
 from tqdm import tqdm
 
 from .. import vision
-from ..types import Model
+from ..types import Model, Platform
 from ..utils import get_field_default
 
 
@@ -107,9 +107,12 @@ def run_inferences(model_cls: Type[Model], input_paths: Sequence[str], postproce
     warning = """WARN: the benchmark results may depend on the number of input samples,
 sizes of the images, and a machine where this benchmark is running."""
     postprocess = postprocess and postprocess.lower()
-    use_native = postprocess != "python"
-    if issubclass(model_cls, (vision.YOLOv5l, vision.YOLOv5m)):
-        use_native = False
+    use_native = any(
+        map(
+            lambda x: x.is_native_platform(),
+            get_field_default(model_cls, "postprocessor_map").keys(),
+        )
+    )
     model = model_cls.load(use_native=use_native)
     queries = len(input_paths)
     print(f"Running {queries} input samples ...")

--- a/furiosa/models/client/api.py
+++ b/furiosa/models/client/api.py
@@ -49,9 +49,10 @@ def get_model_list(filter_func: Optional[Callable[..., bool]] = None) -> List[Li
         model = getattr(vision, model_name)
         if not filter_func(model):
             continue
-        postprocs = ', '.join(
-            map(lambda x: x.name.capitalize(), get_field_default(model, "postprocessor_map").keys())
-        )
+        postproc_map = get_field_default(model, "postprocessor_map")
+        if not postproc_map:
+            raise ValueError(f"No postprocessor map found for {model_name.capitalize()}")
+        postprocs = ', '.join(map(lambda x: x.name.capitalize(), postproc_map.keys()))
         # Model name, description, task type, available post process implementations
         model_list.append([model_name, model.__doc__, prettified_task_type(model), postprocs])
     return model_list

--- a/furiosa/models/types.py
+++ b/furiosa/models/types.py
@@ -29,6 +29,9 @@ class Platform(IntEnum):
     CPP = 2
     RUST = 3
 
+    def is_native_platform(self):
+        return self != self.PYTHON
+
 
 class PostProcessor(ABC):
     def __init__(self, *args, **kwargs):

--- a/furiosa/models/vision/efficientnet_b0/__init__.py
+++ b/furiosa/models/vision/efficientnet_b0/__init__.py
@@ -1,6 +1,6 @@
 import math
 from pathlib import Path
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Dict, List, Sequence, Tuple, Type
 
 from PIL import Image
 import numpy as np
@@ -8,7 +8,7 @@ import numpy.typing as npt
 
 from furiosa.registry.model import Format, Metadata, Publication
 
-from ...types import ImageClassificationModel, PostProcessor, PreProcessor
+from ...types import ImageClassificationModel, Platform, PostProcessor, PreProcessor
 from ...utils import EXT_DFG, EXT_ENF, EXT_ONNX
 from ..common.datasets import imagenet1k
 from ..preprocess import center_crop
@@ -78,6 +78,10 @@ class EfficientNetB0PostProcessor(PostProcessor):
 
 class EfficientNetB0(ImageClassificationModel):
     """EfficientNet B0 model"""
+
+    postprocessor_map: Dict[Platform, Type[PostProcessor]] = {
+        Platform.PYTHON: EfficientNetB0PostProcessor,
+    }
 
     @staticmethod
     def get_artifact_name():


### PR DESCRIPTION
Closes #131 

## Problem
- `furiosa-models list` command is broken
- `furiosa-models bench efficientnetb0` is broken

## Solution
- Decide `use_native` variable properly (no heuristics)
- Add missing postprocessor map
- Elaborate error message when missing postproc map