### PR TITLE
Update artifacts 0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ endif
 
 toolchain:
 	env ONNXRUNTIME_VERSION=1.13.1-2 sh -c 'apt-get install -y --allow-downgrades libonnxruntime=$$ONNXRUNTIME_VERSION'
-	env TOOLCHAIN_VERSION=0.9.0-2+nightly-230125 sh -c 'apt-get install -y --allow-downgrades furiosa-libcompiler=$$TOOLCHAIN_VERSION furiosa-libnux-extrinsic=$$TOOLCHAIN_VERSION furiosa-libnux=$$TOOLCHAIN_VERSION'
-	env LIBHAL_VERSION=0.10.0-2 sh -c 'apt-get install -y --allow-downgrades furiosa-libhal-warboy=$$LIBHAL_VERSION'
+	env TOOLCHAIN_VERSION=0.9.0-2 sh -c 'apt-get install -y --allow-downgrades furiosa-libcompiler=$$TOOLCHAIN_VERSION furiosa-libnux-extrinsic=$$TOOLCHAIN_VERSION furiosa-libnux=$$TOOLCHAIN_VERSION'
+	env LIBHAL_VERSION=0.11.0-2 sh -c 'apt-get install -y --allow-downgrades furiosa-libhal-warboy=$$LIBHAL_VERSION'
 
 lint:
 	isort --diff --check .

--- a/furiosa/models/data/efficientnet_b0.calib_data.yaml.dvc
+++ b/furiosa/models/data/efficientnet_b0.calib_data.yaml.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: ecd632d9c47ce839a477157085a1f4e2
-  size: 21137
+- md5: ec5b9b82b3a2efa8b8e7be898f89ab3a
+  size: 24369
   path: efficientnet_b0.calib_data.yaml

--- a/furiosa/models/data/efficientnet_v2_s.calib_data.yaml.dvc
+++ b/furiosa/models/data/efficientnet_v2_s.calib_data.yaml.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 8667254dc7b188b167f3692b4f07d450
-  size: 54084
+- md5: 9830d14ca531d2e968d2d9972f56beb0
+  size: 62051
   path: efficientnet_v2_s.calib_data.yaml

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/efficientnet_b0_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/efficientnet_b0_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: eeb10952cf0c90f2169658576a265399
+  size: 6675072
+  path: efficientnet_b0_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/efficientnet_b0_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/efficientnet_b0_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: cab920ce63ab41559877a9926855188e
+  size: 22180814
+  path: efficientnet_b0_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/efficientnet_v2_s_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/efficientnet_v2_s_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 92e361f1b2dc9fb5c3ab694104300d21
+  size: 26392468
+  path: efficientnet_v2_s_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/efficientnet_v2_s_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/efficientnet_v2_s_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 2d971cc18579706c4e7dc299188bbf65
+  size: 67643258
+  path: efficientnet_v2_s_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: d2c74915cb45a8c14269f52309d2ca3c
+  size: 26752459
+  path: mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 7a8ff455937c943ade1ba25f51c93619
+  size: 57014173
+  path: mlcommons_resnet50_v1.5_int8_truncated_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_resnet50_v1.5_int8_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_resnet50_v1.5_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: c40d59f00cabb9b6f04e6ab04016f9e0
+  size: 26752785
+  path: mlcommons_resnet50_v1.5_int8_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_resnet50_v1.5_int8_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_resnet50_v1.5_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 4d80ec2c67de6824000ead455539d1e8
+  size: 57013582
+  path: mlcommons_resnet50_v1.5_int8_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 06a1b79a9c2c97e575966425b190310b
+  size: 7503387
+  path: mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 88b0394d8f36a6eddf0155e526d7fd69
+  size: 17273371
+  path: mlcommons_ssd_mobilenet_v1_int8_truncated_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 07367eca97a657355ec9baecf54d71a1
+  size: 7504824
+  path: mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: dde0a5614013d9e9c1cc4ce6584ea950
+  size: 17275759
+  path: mlcommons_ssd_mobilenet_v1_int8_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: bb933bb7bea330e9243013ec848b300f
+  size: 20436471
+  path: mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: eb22d03163b89b76bd41970c63a1c260
+  size: 24793068
+  path: mlcommons_ssd_resnet34_int8_truncated_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_resnet34_int8_warboy_2pe.dfg.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_resnet34_int8_warboy_2pe.dfg.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: b11950c99f9eddff04a1cfeedf61ee58
+  size: 20438499
+  path: mlcommons_ssd_resnet34_int8_warboy_2pe.dfg

--- a/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_resnet34_int8_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.9.0_96bb48a16/mlcommons_ssd_resnet34_int8_warboy_2pe.enf.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 7293ecd6f506bd43684207f2ac4f5bd9
+  size: 24795996
+  path: mlcommons_ssd_resnet34_int8_warboy_2pe.enf


### PR DESCRIPTION
NOTE: These artifacts are built on sdk 0.9.0-rc5.

Updated calibration methods on efficientnet-b0, with updated accuracy to `73.556` (previously, `16.104`).
```
>       assert accuracy == EXPECTED_ACCURACY, "Accuracy check failed"
E       AssertionError: Accuracy check failed
E       assert 73.556 == 16.104

tests/bench/test_efficientnet_b0.py:56: AssertionError

---------------------------------------------------- benchmark: 1 tests ---------------------------------------------------
Name (time in ms)                   Min       Max     Mean  StdDev   Median     IQR   Outliers      OPS  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------
test_efficientnetb0_accuracy     8.0916  457.8515  20.9568  8.9175  20.4500  5.3315  1463;1017  47.7171   50000           1
---------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
====================================================== short test summary info =======================================================
FAILED tests/bench/test_efficientnet_b0.py::test_efficientnetb0_accuracy - AssertionError: Accuracy check failed
=================================================== 1 failed in 1060.82s (0:17:40) ===================================================
100%|██████████████████████████████████████████████████████████████████████████████████████████▉| 49999/50000 [17:33<00:00, 47.46it/s]

```

Also for efficientnetv2s, as follows. (`75.208` => `83.566`)
```
>       assert accuracy == EXPECTED_ACCURACY, "Accuracy check failed"
E       AssertionError: Accuracy check failed
E       assert 83.566 == 75.208

tests/bench/test_efficientnet_v2_s.py:56: AssertionError

------------------------------------------------------ benchmark: 1 tests ------------------------------------------------------
Name (time in ms)                     Min         Max     Mean   StdDev   Median     IQR   Outliers      OPS  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------
test_efficientnetv2s_accuracy     16.2072  1,161.0729  45.7795  11.6128  44.8509  3.7553  1488;3048  21.8439   50000           1
--------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
====================================================== short test summary info =======================================================
FAILED tests/bench/test_efficientnet_v2_s.py::test_efficientnetv2s_accuracy - AssertionError: Accuracy check failed
=================================================== 1 failed in 2303.66s (0:38:23) ===================================================
100%|██████████████████████████████████████████████████████████████████████████████████████████▉| 49999/50000 [38:20<00:00, 21.74it/s]
```
