### PR TITLE
Use accelerated s3 endpoint & enable local cache

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -4,7 +4,7 @@
     type = "hardlink,symlink"
     dir = cache
 ['remote "origin"']
-    url = https://furiosa-public-artifacts.s3.amazonaws.com/furiosa-artifacts
+    url = https://furiosa-public-artifacts.s3-accelerate.amazonaws.com/furiosa-artifacts
 ['remote "s3origin"']
     url = s3://furiosa-public-artifacts/furiosa-artifacts
     acl = public-read

--- a/furiosa/models/utils.py
+++ b/furiosa/models/utils.py
@@ -28,7 +28,9 @@ CACHE_DIRECTORY_BASE = Path(
     )
 )
 
-DVC_PUBLIC_HTTP_ENDPOINT = "https://furiosa-public-artifacts.s3.amazonaws.com/furiosa-artifacts"
+DVC_PUBLIC_HTTP_ENDPOINT = (
+    "https://furiosa-public-artifacts.s3-accelerate.amazonaws.com/furiosa-artifacts"
+)
 
 module_logger = logging.getLogger(__name__)
 

--- a/furiosa/models/utils.py
+++ b/furiosa/models/utils.py
@@ -24,7 +24,7 @@ DATA_DIRECTORY_BASE = Path(__file__).parent / "data"
 CACHE_DIRECTORY_BASE = Path(
     os.getenv(
         "FURIOSA_MODELS_CACHE_HOME",
-        os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "furiosa/models"),
+        os.path.join(os.getenv("XDG_CACHE_HOME", Path.home() / ".cache"), "furiosa/models"),
     )
 )
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,8 +1,8 @@
-from furiosa.models.utils import compiler_version
+from furiosa.models.utils import get_nux_version
 
 
 def test_compiler_version():
-    version = compiler_version()
+    version = get_nux_version()
     assert version
     assert len(version.version) > 0
     assert len(version.revision) > 0


### PR DESCRIPTION
- [x] model zoo 의 download가 해외에서 느린 문제 (cloudfront or multi region s3) (테스트는 viso 머신등에서 할 수 있을 것 같습니다)
  - s3 accelerate 기능을 켰고, 관련해서 endpoint로 변경했습니다.
- [x] local storage cache 기능
  - 일단 만들어 두었는데, 원본 f32 onnx를 다른 compiler toolchain version 끼리 공유하지 못하는 상태입니다. 이건 그런데 `furiosa-artifacts` 를 새로 디자인 하면서 해결하려고 합니다. 일단 지금처럼만 구현해 두어도 효용이 있을 것 같습니다.

아래는 따로 PR 열려고 합니다. compiled enf / onnx+range 둘 중 하나만 가지고도 Model을 유용하게 쓸 수 있는데 현재는 모두 resolve 하고 있는데 이를 같이 해결하고 싶어서 문제를 분리하려고 합니다. 잘 다듬어서 다시 PR 열겠습니다.
- [ ] ~컴파일 버전된 버전이 없을 경우 원본이 전달 되도록 개선~