### PR TITLE
Lazily load model artifacts

### DIFF
--- a/docs/examples/loading_model_nonblocking.py
+++ b/docs/examples/loading_model_nonblocking.py
@@ -1,6 +1,0 @@
-import asyncio
-
-from furiosa.models.types import Model
-from furiosa.models.vision import ResNet50
-
-model: Model = asyncio.run(ResNet50.load_async())

--- a/docs/examples/ssd_mobilenet.py
+++ b/docs/examples/ssd_mobilenet.py
@@ -7,4 +7,4 @@ mobilenet = SSDMobileNet.load()
 with session.create(mobilenet.enf) as sess:
     inputs, contexts = mobilenet.preprocess(image)
     outputs = sess.run(inputs).numpy()
-    mobilenet.postprocess(outputs, contexts)
+    mobilenet.postprocess(outputs, contexts[0])

--- a/docs/examples/ssd_mobilenet_onnx.py
+++ b/docs/examples/ssd_mobilenet_onnx.py
@@ -19,4 +19,4 @@ dfg = quantize(onnx_model, calib_range, with_quantize=False)
 with session.create(dfg, compiler_config=compiler_config) as sess:
     inputs, contexts = mobilenet.preprocess(image)
     outputs = sess.run(inputs).numpy()
-    mobilenet.postprocess(outputs, contexts)
+    mobilenet.postprocess(outputs, contexts[0])

--- a/docs/model_object.md
+++ b/docs/model_object.md
@@ -10,17 +10,9 @@ the model images are not included in Python package. When `load()` method is cal
 fetched over the network. It takes some time (usually few seconds) depending on models and network conditions.
 Once the model images are fetched, they will be cached on a local disk.
 
-Non-blocking API `load_async()` also is available, and it can be used
-if your application is running through asynchronous executors (e.g., asyncio).
-
 === "Blocking API"
     ```python
     --8<-- "docs/examples/loading_model.py"
-    ```
-
-=== "Non-blocking API"
-    ```python
-    --8<-- "docs/examples/loading_model_nonblocking.py"
     ```
 
 <a name="accessing_artifacts_and_metadata"></a>

--- a/furiosa/models/vision/efficientnet_b0/__init__.py
+++ b/furiosa/models/vision/efficientnet_b0/__init__.py
@@ -120,12 +120,9 @@ class EfficientNetB0(ImageClassificationModel):
         return "efficientnet_b0"
 
     @classmethod
-    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = False, *args, **kwargs):
+    def load(cls, use_native: bool = False):
         return cls(
             name="EfficientNetB0",
-            source=artifacts[EXT_ONNX],
-            enf=artifacts[EXT_ENF],
-            calib_yaml=artifacts[EXT_CALIB_YAML],
             format=Format.ONNX,
             family="EfficientNet",
             version="1.0.2",

--- a/furiosa/models/vision/efficientnet_v2_s/__init__.py
+++ b/furiosa/models/vision/efficientnet_v2_s/__init__.py
@@ -122,13 +122,10 @@ class EfficientNetV2s(ImageClassificationModel):
         return "efficientnet_v2_s"
 
     @classmethod
-    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = False, *args, **kwargs):
+    def load(cls, use_native: bool = False):
         postprocessor = get_field_default(cls, "postprocessor_map")[Platform.PYTHON]()
         return cls(
             name="EfficientNetV2s",
-            source=artifacts[EXT_ONNX],
-            enf=artifacts[EXT_ENF],
-            calib_yaml=artifacts[EXT_CALIB_YAML],
             format=Format.ONNX,
             family="EfficientNetV2",
             version="s",

--- a/furiosa/models/vision/resnet50/__init__.py
+++ b/furiosa/models/vision/resnet50/__init__.py
@@ -88,12 +88,9 @@ class ResNet50(ImageClassificationModel):
         return "mlcommons_resnet50_v1.5"
 
     @classmethod
-    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = False, *args, **kwargs):
+    def load(cls, use_native: bool = False):
         return cls(
             name="ResNet50",
-            source=artifacts[EXT_ONNX],
-            enf=artifacts[EXT_ENF],
-            calib_yaml=artifacts[EXT_CALIB_YAML],
             format=Format.ONNX,
             family="ResNet",
             version="v1.5",

--- a/furiosa/models/vision/ssd_mobilenet/__init__.py
+++ b/furiosa/models/vision/ssd_mobilenet/__init__.py
@@ -323,15 +323,12 @@ class SSDMobileNet(ObjectDetectionModel):
         return "mlcommons_ssd_mobilenet_v1"
 
     @classmethod
-    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = True):
+    def load(cls, use_native: bool = True):
         postproc_type = Platform.RUST if use_native else Platform.PYTHON
         logger.debug(f"Using {postproc_type.name} postprocessor")
         postprocessor = get_field_default(cls, "postprocessor_map")[postproc_type]()
         return cls(
             name="MLCommonsSSDMobileNet",
-            source=artifacts[EXT_ONNX],
-            enf=artifacts[EXT_ENF],
-            calib_yaml=artifacts[EXT_CALIB_YAML],
             format=Format.ONNX,
             family="MobileNetV1",
             version="v1.1",

--- a/furiosa/models/vision/ssd_resnet34/__init__.py
+++ b/furiosa/models/vision/ssd_resnet34/__init__.py
@@ -431,15 +431,12 @@ class SSDResNet34(ObjectDetectionModel):
         return "mlcommons_ssd_resnet34"
 
     @classmethod
-    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = True):
+    def load(cls, use_native: bool = True):
         postproc_type = Platform.RUST if use_native else Platform.PYTHON
         logger.debug(f"Using {postproc_type.name} postprocessor")
         postprocessor = get_field_default(cls, "postprocessor_map")[postproc_type]()
         return cls(
             name="SSDResNet34",
-            source=artifacts[EXT_ONNX],
-            enf=artifacts[EXT_ENF],
-            calib_yaml=artifacts[EXT_CALIB_YAML],
             format=Format.ONNX,
             family="ResNet",
             version="v1.1",

--- a/furiosa/models/vision/yolov5/large.py
+++ b/furiosa/models/vision/yolov5/large.py
@@ -31,14 +31,11 @@ class YOLOv5l(YOLOv5Base):
         return "yolov5l"
 
     @classmethod
-    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = False, *args, **kwargs):
+    def load(cls, use_native: bool = False):
         if use_native:
             raise NotImplementedError("No native implementation for YOLOv5")
         return cls(
             name="YOLOv5Large",
-            source=artifacts[EXT_ONNX],
-            enf=artifacts[EXT_ENF],
-            calib_yaml=artifacts[EXT_CALIB_YAML],
             format=Format.ONNX,
             family="YOLOv5",
             version="v5",

--- a/furiosa/models/vision/yolov5/medium.py
+++ b/furiosa/models/vision/yolov5/medium.py
@@ -31,14 +31,11 @@ class YOLOv5m(YOLOv5Base):
         return "yolov5m"
 
     @classmethod
-    def load_aux(cls, artifacts: Dict[str, bytes], use_native: bool = False, *args, **kwargs):
+    def load(cls, use_native: bool = False):
         if use_native:
             raise NotImplementedError("No native implementation for YOLOv5")
         return cls(
             name="YOLOv5Medium",
-            source=artifacts[EXT_ONNX],
-            enf=artifacts[EXT_ENF],
-            calib_yaml=artifacts[EXT_CALIB_YAML],
             format=Format.ONNX,
             family="YOLOv5",
             version="v5",

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -24,7 +24,7 @@ def test_mlcommons_resnet50():
 @pytest.mark.asyncio
 async def test_mlcommons_resnet50_async():
     sanity_check_for_dvc_file(
-        await ResNet50.load_async(),
+        await ResNet50.load(),
         next((DATA_DIRECTORY_BASE / "mlcommons_resnet50_v1.5").glob("*.onnx.dvc")),
     )
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1,6 +1,5 @@
 # Add all published models to make sure if the fetched model image is correct.
 
-import pytest
 import yaml
 
 from furiosa.models.utils import DATA_DIRECTORY_BASE
@@ -17,14 +16,6 @@ def sanity_check_for_dvc_file(model, dvc_file_path: str):
 def test_mlcommons_resnet50():
     sanity_check_for_dvc_file(
         ResNet50.load(use_native=False),
-        next((DATA_DIRECTORY_BASE / "mlcommons_resnet50_v1.5").glob("*.onnx.dvc")),
-    )
-
-
-@pytest.mark.asyncio
-async def test_mlcommons_resnet50_async():
-    sanity_check_for_dvc_file(
-        await ResNet50.load(),
         next((DATA_DIRECTORY_BASE / "mlcommons_resnet50_v1.5").glob("*.onnx.dvc")),
     )
 

--- a/tests/unit/test_batched_yolov5l.py
+++ b/tests/unit/test_batched_yolov5l.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import cv2
 import numpy as np
-import pytest
 
 from furiosa.models.vision import YOLOv5l
 from furiosa.models.vision.postprocess import collate
@@ -15,9 +14,8 @@ NUM_BATCHES = 2
 NUM_DETECTED_BOXES = 26
 
 
-@pytest.mark.asyncio
-async def test_yolov5_large_batched():
-    m = await YOLOv5l.load_async()
+def test_yolov5_large_batched():
+    m = YOLOv5l.load()
     assert len(m.classes) == NUM_CLASSES, "expected CLASS is 10"
 
     batch_im = [cv2.imread(TEST_IMAGE_PATH), cv2.imread(TEST_IMAGE_PATH)]

--- a/tests/unit/test_batched_yolov5m.py
+++ b/tests/unit/test_batched_yolov5m.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import cv2
 import numpy as np
-import pytest
 
 from furiosa.models.vision import YOLOv5m
 from furiosa.models.vision.postprocess import collate
@@ -15,9 +14,8 @@ NUM_BATCHES = 2
 NUM_DETECTED_BOXES = 21
 
 
-@pytest.mark.asyncio
-async def test_yolov5_medium_batched():
-    m = await YOLOv5m.load_async()
+def test_yolov5_medium_batched():
+    m = YOLOv5m.load()
     assert len(m.classes) == NUM_CLASSES, "expected CLASS is 10"
 
     batch_im = [cv2.imread(TEST_IMAGE_PATH), cv2.imread(TEST_IMAGE_PATH)]


### PR DESCRIPTION
Also, remove `model.load_async()` function for simplicity.
Added `model.resolve_all()` function to resolve all the artifacts at once.

Nits: use native postprocess for mobilenet and modified related example codes.