### PR TITLE
Wait for the docker image in regression test

### DIFF
--- a/tekton/furiosa-models-regression-test/label-trigger.yaml
+++ b/tekton/furiosa-models-regression-test/label-trigger.yaml
@@ -231,6 +231,17 @@ spec:
     - name: depth
       value: $(params.gitCloneDepth)
 
+  - name: wait-for-image
+    taskRef:
+      name: wait-for-image
+    workspaces:
+      - name: aws-credential
+        workspace: aws-credential
+    resources:
+      inputs:
+        - name: image
+          resource: image
+
   - name: regression-test-with-npu
     taskRef:
       name: regression-test-with-npu
@@ -267,7 +278,7 @@ spec:
         - name: image
           resource: image
     runAfter:
-      - clone
+      - wait-for-image
 
   finally:
   - name: set-status-success

--- a/tekton/furiosa-models-regression-test/regression-test.yaml
+++ b/tekton/furiosa-models-regression-test/regression-test.yaml
@@ -1,6 +1,34 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
+  name: wait-for-image
+  namespace: ci-furiosa-models
+spec:
+  workspaces:
+    - name: aws-credential
+      mountPath: /root/.aws
+  resources:
+    inputs:
+      - name: image
+        type: image
+  steps:
+    - name: wait-for-image
+      image: "docker:23.0-cli"
+      env:
+      - name: IMAGE
+        value: $(resources.inputs.image.url)
+      script: |
+        echo "Wating for image: $IMAGE"
+        while :
+        do
+          docker manifest inspect $IMAGE > /dev/null \
+            && break
+          sleep 60s
+        done
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
   name: regression-test-with-npu
   namespace: ci-furiosa-models
 spec:


### PR DESCRIPTION
### Problem
- label-triggered jobs should be triggered after pushing image

### Solution
- In label-triggered regression tests, add task step to wait for the docker image to be pushed

### Note
This change has already been tested & applied