### PR TITLE
Minor modifications

### DIFF
--- a/docs/examples/ssd_mobilenet_onnx.py
+++ b/docs/examples/ssd_mobilenet_onnx.py
@@ -15,6 +15,12 @@ calib_range: dict = mobilenet.tensor_name_to_range
 quantized_onnx = quantize(onnx_model, calib_range)
 
 with create_runner(quantized_onnx, compiler_config=compiler_config) as runner:
+    # Models in the Model Zoo have built-in optimizations that, by default,
+    # bypass normalization, quantization, and type conversion. If you compile
+    # and utilize these models without employing these optimizations, it's
+    # necessary to set up preprocessing steps to incorporate normalization and
+    # type casting. To accomplish this, you should introduce an extra parameter,
+    # `with_scaling=True`.
     inputs, contexts = mobilenet.preprocess(image, with_scaling=True)
     outputs = runner.run(inputs)
     mobilenet.postprocess(outputs, contexts[0])

--- a/furiosa/models/client/api.py
+++ b/furiosa/models/client/api.py
@@ -3,6 +3,8 @@ from typing import Callable, List, Optional, Sequence, Type
 
 from tqdm import tqdm
 
+from furiosa.runtime.sync import create_runner
+
 from .. import vision
 from ..types import Model, PythonPostProcessor
 
@@ -102,8 +104,6 @@ def decorate_result(
 
 
 def run_inferences(model_cls: Type[Model], input_paths: Sequence[str], postprocess: Optional[str]):
-    from furiosa.runtime.sync import create_runner
-
     warning = """WARN: the benchmark results may depend on the number of input samples,
 sizes of the images, and a machine where this benchmark is running."""
     if postprocess:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,20 @@ Documentation = "https://furiosa-ai.github.io/furiosa-models/latest/"
 [tool.flit.module]
 name = "furiosa.models"
 
-[tool.flit.external-data]
-directory = "furiosa/models/data"
+[tool.flit.sdist]
+exclude = [
+    '.dvc',
+    '.dvcignore',
+    '.github',
+    '.gitignore',
+    'Makefile',
+    'ci-constraints.txt',
+    'docker',
+    'docs',
+    'mkdocs.yml',
+    'tekton',
+    'tests',
+]
 
 [tool.pytest.ini_options]
 addopts = "--benchmark-autosave"


### PR DESCRIPTION
1. FuriosaAI SDK 0.10.0의 새 런타임은 TLS 부족 이슈를 겪고 있는데요, torch보다 import를 먼저 하면 libgomp의 TLS 가 부족하다고 에러가 나고, torch를 먼저 import 하면 native runtime의 TLS가 부족하다고 에러가 납니다.
- native runtime과 libgomp 중 libgomp를 preload 하는 것으로 문제를 우회할 수 있는데요, 이러려면 torch를 늦게 import 해서 libgomp의 에러 메시지를 보여주는 것이 유리합니다.
- 예전에는 furiosa-runtime이 furiosa-models의 선택 의존성이라 import 하는 부분을 함수 안에 넣어놨었는데요, 지금은 그렇지 않고 먼저 import 하는 것이 장점도 있으므로 import를 먼저 하게 바꿉니다.
2. flit이 packaging 할 때 파이썬 패키지와 관련 없는 파일들도 패키징 하고 있는데요, 그러지 않도록 메타데이터를 잘 설정하게 바꿨습니다.
3. with_scaling 인자에 대해서 예시 코드에도 자세한 주석을 추가했습니다.