### PR TITLE
Use furiosa-compiler instead of furiosa.tools.compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash -o pipefail
 
 ONNXRUNTIME_VERSION := 1.15.1-?
-TOOLCHAIN_VERSION := 0.10.0-?
+TOOLCHAIN_VERSION := 0.10.2-?
 LIBHAL_VERSION := 0.11.0-?
 
 .PHONY: check-docker-tag toolchain lint test unit_tests notebook_tests examples \
@@ -18,8 +18,6 @@ toolchain:
 	apt-get update
 	apt-get install -y --allow-downgrades libonnxruntime=$(ONNXRUNTIME_VERSION)
 	apt-get install -y --allow-downgrades furiosa-compiler=$(TOOLCHAIN_VERSION)
-	# TODO: remove me when possible
-	apt-get install -y --allow-downgrades furiosa-libcompiler=$(TOOLCHAIN_VERSION)
 	apt-get install -y --allow-downgrades furiosa-libhal-warboy=$(LIBHAL_VERSION)
 
 lint:

--- a/furiosa/models/_utils.py
+++ b/furiosa/models/_utils.py
@@ -29,7 +29,7 @@ DVC_PUBLIC_HTTP_ENDPOINT = (
 module_logger = logging.getLogger(__name__)
 
 
-def get_version_info() -> str:
+def get_ir_version() -> str:
     try:
         compiler_info = subprocess.run(
             ['furiosa-compiler', '--version'], capture_output=True, text=True, check=True
@@ -73,7 +73,7 @@ def get_from_url(path: str, uri: Path, is_legacy_path: bool = False) -> bytes:
                 return get_from_url(f"files/md5/{path}", uri, True)
             raise errors.NotFoundInDVCRemote(uri, path)
         data = resp.content
-        caching_path = CACHE_DIRECTORY_BASE / get_version_info() / (uri.name)
+        caching_path = CACHE_DIRECTORY_BASE / get_ir_version() / (uri.name)
         module_logger.debug(f"caching to {caching_path}")
         caching_path.parent.mkdir(parents=True, exist_ok=True)
         with open(caching_path, mode="wb") as f:
@@ -94,7 +94,7 @@ class ArtifactResolver:
 
     def _read(self, directory: str, filename: str) -> bytes:
         # Try to find local cached file
-        local_cache_path = CACHE_DIRECTORY_BASE / get_version_info() / (self.uri.name)
+        local_cache_path = CACHE_DIRECTORY_BASE / get_ir_version() / (self.uri.name)
         if local_cache_path.exists():
             module_logger.debug(f"Local cache exists: {local_cache_path}")
             with open(local_cache_path, mode="rb") as f:
@@ -134,7 +134,7 @@ def resolve_source(src_name: str, extension: str) -> bytes:
 
 
 def resolve_model_source(src_name: str, num_pe: int = 2) -> bytes:
-    version_info = get_version_info()
+    version_info = get_ir_version()
     if version_info is None:
         raise errors.VersionInfoNotFound()
     generated_path_base = DATA_DIRECTORY_BASE / f"generated/{version_info}"

--- a/furiosa/models/_utils.py
+++ b/furiosa/models/_utils.py
@@ -28,10 +28,12 @@ module_logger = logging.getLogger(__name__)
 
 
 def get_version_info() -> Optional[str]:
-    from furiosa.tools.compiler.api import VersionInfo
+    try:
+        from furiosa.native_runtime import __git_short_hash__, __version__
 
-    version_info = VersionInfo()
-    return f"{version_info.version}_{version_info.git_hash}"
+        return f"{__version__}_{__git_short_hash__}"
+    except ImportError:
+        return None
 
 
 def find_dvc_cache_directory(path: Path) -> Optional[Path]:

--- a/furiosa/models/_utils.py
+++ b/furiosa/models/_utils.py
@@ -1,6 +1,8 @@
 import logging
 import os
 from pathlib import Path
+import re
+import subprocess
 from typing import TYPE_CHECKING, Collection, Optional, Tuple, Union
 
 if TYPE_CHECKING:
@@ -27,13 +29,21 @@ DVC_PUBLIC_HTTP_ENDPOINT = (
 module_logger = logging.getLogger(__name__)
 
 
-def get_version_info() -> Optional[str]:
+def get_version_info() -> str:
     try:
-        from furiosa.native_runtime import __git_short_hash__, __version__
-
-        return f"{__version__}_{__git_short_hash__}"
-    except ImportError:
-        return None
+        compiler_info = subprocess.run(
+            ['furiosa-compiler', '--version'], capture_output=True, text=True, check=True
+        ).stdout
+    except FileNotFoundError:
+        raise RuntimeError("furiosa-compiler is not installed")
+    pattern = r"frontend:\n- version: (.+?)\n- revision: (.+?)\b"
+    match = re.search(pattern, compiler_info)
+    if match:
+        version = match.group(1)
+        git_hash = match.group(2)
+        return f"{version}_{git_hash}"
+    else:
+        raise RuntimeError("Cannot parse furiosa-compiler version info")
 
 
 def find_dvc_cache_directory(path: Path) -> Optional[Path]:
@@ -45,6 +55,9 @@ def find_dvc_cache_directory(path: Path) -> Optional[Path]:
 
 
 def parse_dvc_file(file_path: Path) -> Tuple[str, str, int]:
+    dvc_path = Path(f"{file_path}.dvc")
+    if not dvc_path.exists():
+        raise FileNotFoundError(f"{dvc_path} not found, are you in development mode?")
     info_dict = yaml.safe_load(open(f"{file_path}.dvc").read())["outs"][0]
     md5sum = info_dict["md5"]
     return md5sum[:2], md5sum[2:], info_dict["size"]
@@ -113,18 +126,11 @@ class ArtifactResolver:
         return data
 
 
-def resolve_artifact(src_name: str, full_path: Path) -> bytes:
-    try:
-        return ArtifactResolver(full_path).read()
-    except Exception as e:
-        raise errors.ArtifactNotFound(f"{src_name}:{full_path}") from e
-
-
 def resolve_source(src_name: str, extension: str) -> bytes:
     full_path = next((DATA_DIRECTORY_BASE / src_name).glob(f'*.{extension}.dvc'))
     # Remove `.dvc` suffix
     full_path = full_path.with_suffix('')
-    return resolve_artifact(src_name, full_path)
+    return ArtifactResolver(full_path).read()
 
 
 def resolve_model_source(src_name: str, num_pe: int = 2) -> bytes:
@@ -150,7 +156,7 @@ def resolve_model_source(src_name: str, num_pe: int = 2) -> bytes:
             editor.convert_input_type(input_name, TensorType.UINT8)
         return quantize(onnx_model, calib_range)
     file_name = f'{src_name}_warboy_{num_pe}pe.enf'
-    return resolve_artifact(src_name, generated_path_base / file_name)
+    return ArtifactResolver(generated_path_base / file_name).read()
 
 
 def validate_postprocessor_type(

--- a/furiosa/models/_utils.py
+++ b/furiosa/models/_utils.py
@@ -36,7 +36,7 @@ def get_version_info() -> str:
         ).stdout
     except FileNotFoundError:
         raise RuntimeError("furiosa-compiler is not installed")
-    pattern = r"frontend:\n- version: (.+?)\n- revision: (.+?)\b"
+    pattern = r"backend:\n- version: (.+?)\n- revision: (.+?)\b"
     match = re.search(pattern, compiler_info)
     if match:
         version = match.group(1)

--- a/furiosa/models/data/enf_generator.py
+++ b/furiosa/models/data/enf_generator.py
@@ -18,7 +18,7 @@ COMPILER_CONFIG = {"lower_tabulated_dequantize": True}
 compiler_info = sp.run(
     ['furiosa-compiler', '--version'], capture_output=True, text=True, check=True
 ).stdout
-pattern = r"frontend:\n- version: (.+?)\n- revision: (.+?)\b"
+pattern = r"backend:\n- version: (.+?)\n- revision: (.+?)\b"
 match = re.search(pattern, compiler_info)
 if match:
     version = match.group(1)
@@ -86,6 +86,7 @@ def quantize_and_compile_model(arg: Tuple[int, Path, int]):
             shlex.split(cmd),
             env={"NPU_COMPILER_CONFIG_PATH": compiler_config_path},
             check=True,
+            stderr=sp.DEVNULL,
         )
 
         # Manually remove compiler config file (as we use mkstemp)

--- a/furiosa/models/data/enf_generator.py
+++ b/furiosa/models/data/enf_generator.py
@@ -2,6 +2,9 @@ from itertools import product
 from multiprocessing import Pool
 import os
 from pathlib import Path
+import re
+import shlex
+import subprocess as sp
 import tempfile
 from typing import Tuple
 
@@ -9,28 +12,29 @@ import onnx
 import yaml
 
 from furiosa.quantizer import ModelEditor, TensorType, get_pure_input_names, quantize
-from furiosa.tools.compiler.api import VersionInfo, compile
 
 COMPILER_CONFIG = {"lower_tabulated_dequantize": True}
 
+compiler_info = sp.run(
+    ['furiosa-compiler', '--version'], capture_output=True, text=True, check=True
+).stdout
+pattern = r"frontend:\n- version: (.+?)\n- revision: (.+?)\b"
+match = re.search(pattern, compiler_info)
+if match:
+    version = match.group(1)
+    git_hash = match.group(2)
+else:
+    raise RuntimeError("Cannot parse furiosa-compiler version info")
+
 base_path = Path(__file__).parent
-compiler_version = VersionInfo()
-print(f"furiosa-compiler {compiler_version.version} (rev. {compiler_version.git_hash})")
+print(f"furiosa-compiler {version} (rev. {git_hash})")
 model_directories = [p for p in base_path.glob('*') if p.is_dir() and 'generated' not in p.name]
 model_directories = list(enumerate(sorted(model_directories), start=1))
 print(f"Found {len(model_directories)} ONNX model files:")
 print('\n'.join(map(lambda x: f" {x[0]}. {x[1].name}", model_directories)))
-generated_path = base_path / f"generated/{compiler_version.version}_{compiler_version.git_hash}"
+generated_path = base_path / f"generated/{version}_{git_hash}"
 generated_path.mkdir(parents=True, exist_ok=True)
 print(f"Output directory: {generated_path}")
-
-
-def set_compiler_config(compiler_config: dict):
-    # Make and set compiler config
-    fd, compiler_config_path = tempfile.mkstemp()
-    with os.fdopen(fd, "w") as f:
-        yaml.dump(compiler_config, f)
-    os.environ['NPU_COMPILER_CONFIG_PATH'] = compiler_config_path
 
 
 def quantize_and_compile_model(arg: Tuple[int, Path, int]):
@@ -56,33 +60,43 @@ def quantize_and_compile_model(arg: Tuple[int, Path, int]):
     for input_name in get_pure_input_names(onnx_model):
         editor.convert_input_type(input_name, TensorType.UINT8)
     quantized_onnx = quantize(onnx_model, calib_ranges)
-    print(f"  [{index}] {model_short_name} quantized", flush=True)
+    with tempfile.NamedTemporaryFile() as quantized_onnx_file:
+        onnx.save(quantized_onnx, quantized_onnx_file.name)
+        print(f"  [{index}] {model_short_name} quantized", flush=True)
 
-    compiler_config = dict(COMPILER_CONFIG)
-    compiler_config_path = model_dir_path / "compiler_config.yaml"
-    if compiler_config_path.exists() and compiler_config_path.is_file():
-        print(f"   [{index}] {model_short_name} has extra compiler config: ", flush=True, end='')
-        with open(compiler_config_path) as f:
-            additional_compiler_config = yaml.full_load(f)
-            print(str(additional_compiler_config), flush=True)
-            compiler_config.update(additional_compiler_config)
-    set_compiler_config(compiler_config)
+        # Acquire compiler config
+        compiler_config = dict(COMPILER_CONFIG)
+        additional_config = model_dir_path / "compiler_config.yaml"
+        if additional_config.exists() and additional_config.is_file():
+            print(f"   [{index}] {model_short_name} has extra compiler config: ", flush=True)
+            with open(additional_config) as f:
+                additional_compiler_config = yaml.full_load(f)
+                print(str(additional_compiler_config), flush=True)
+                compiler_config.update(additional_compiler_config)
 
-    with open('/dev/null', 'w') as devnull:
-        # Redirect C lib's stderr to /dev/null
-        os.dup2(devnull.fileno(), 2)
+        # Write compiler config to temp file
+        fd, compiler_config_path = tempfile.mkstemp()
+        with os.fdopen(fd, "w") as f:
+            yaml.dump(compiler_config, f)
 
         # Compile and write to file
         target_npu = "warboy" if num_pe == 1 else "warboy-2pe"
-        enf = compile(bytes(quantized_onnx), target_npu=target_npu)
-        with open(enf_path, 'wb') as f:
-            f.write(enf)
+        cmd = f'furiosa-compiler --target-npu {target_npu} --output {enf_path} {quantized_onnx_file.name}'
+        sp.run(
+            shlex.split(cmd),
+            env={"NPU_COMPILER_CONFIG_PATH": compiler_config_path},
+            check=True,
+        )
+
+        # Manually remove compiler config file (as we use mkstemp)
+        Path(compiler_config_path).unlink()
+
         print(f"  [{index}] {model_short_name} compiled to {enf_path}", flush=True)
 
 
 if __name__ == '__main__':
     lst = product(model_directories, [1, 2])  # [(idx, model_dir_path, num_pe), ...]
-    lst = [(a, b, c) for (a, b), c in lst]
+    lst = [(a, b, c) for (a, b), c in lst]  # Flatten list
 
     # Do the job parallelly
     with Pool() as pool:

--- a/furiosa/models/data/generated/0.10.0_f8f05c8ea/efficientnet_v2_s_warboy_1pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.0_f8f05c8ea/efficientnet_v2_s_warboy_1pe.enf.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 621c7fca75cce85a2a13619c349f30b0
+- md5: c20f415ff6ecdac8ac36d77153d8b072
   size: 44861541
   hash: md5
   path: efficientnet_v2_s_warboy_1pe.enf

--- a/furiosa/models/data/generated/0.10.0_f8f05c8ea/efficientnet_v2_s_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.0_f8f05c8ea/efficientnet_v2_s_warboy_2pe.enf.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: d084dfd1b5138294713c31257a0d264d
+- md5: ec8732710b0b792af79e8c436bb452d1
   size: 67662577
   hash: md5
   path: efficientnet_v2_s_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.10.0_f8f05c8ea/mlcommons_ssd_mobilenet_v1_warboy_1pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.0_f8f05c8ea/mlcommons_ssd_mobilenet_v1_warboy_1pe.enf.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 71256730cb32eba5454109d5da82a09f
+- md5: 7f5bf11012845ba17c985f7365f69106
   size: 16474290
   hash: md5
   path: mlcommons_ssd_mobilenet_v1_warboy_1pe.enf

--- a/furiosa/models/data/generated/0.10.0_f8f05c8ea/mlcommons_ssd_mobilenet_v1_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.0_f8f05c8ea/mlcommons_ssd_mobilenet_v1_warboy_2pe.enf.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 7a55ebcf34cfa3a2ae047dc8272a0a54
+- md5: 515364e6a66f713d2d896664aeaabb07
   size: 17356401
   hash: md5
   path: mlcommons_ssd_mobilenet_v1_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.10.0_f8f05c8ea/mlcommons_ssd_resnet34_warboy_1pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.0_f8f05c8ea/mlcommons_ssd_resnet34_warboy_1pe.enf.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: c41d85d99620f796f2159b6b3f6d6bdb
+- md5: 8ebef4411a4dc2c6dd5a07f94e7d4ed0
   size: 24005454
   hash: md5
   path: mlcommons_ssd_resnet34_warboy_1pe.enf

--- a/furiosa/models/data/generated/0.10.0_f8f05c8ea/mlcommons_ssd_resnet34_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.0_f8f05c8ea/mlcommons_ssd_resnet34_warboy_2pe.enf.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: fd61992e1b93bdd99f07e30f19aa0a53
+- md5: 5a591bceabc9fa5043387ed54e73a231
   size: 24830635
   hash: md5
   path: mlcommons_ssd_resnet34_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/efficientnet_b0_warboy_1pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/efficientnet_b0_warboy_1pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 57b64a9e4ced03d2cf755acd87b0a615
+  size: 17798664
+  hash: md5
+  path: efficientnet_b0_warboy_1pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/efficientnet_b0_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/efficientnet_b0_warboy_2pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: b49b7bd3b6a75bf63c3dd8f6bfa3abc8
+  size: 22193001
+  hash: md5
+  path: efficientnet_b0_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/efficientnet_v2_s_warboy_1pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/efficientnet_v2_s_warboy_1pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 7b0c5b7ba3da88f8b6df7ab238f22390
+  size: 44861541
+  hash: md5
+  path: efficientnet_v2_s_warboy_1pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/efficientnet_v2_s_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/efficientnet_v2_s_warboy_2pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: b3f5bddb6c06ed74f17ef751e58d58c3
+  size: 67662577
+  hash: md5
+  path: efficientnet_v2_s_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_resnet50_v1.5_warboy_1pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_resnet50_v1.5_warboy_1pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 029775d471858db1621679ad394179c9
+  size: 39525369
+  hash: md5
+  path: mlcommons_resnet50_v1.5_warboy_1pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_resnet50_v1.5_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_resnet50_v1.5_warboy_2pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: a978a84d74a2a113ea31cb7a80750d02
+  size: 57063777
+  hash: md5
+  path: mlcommons_resnet50_v1.5_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_ssd_mobilenet_v1_warboy_1pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_ssd_mobilenet_v1_warboy_1pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: febd7c78756f5fa5ba6bf3628e3d4b21
+  size: 16474290
+  hash: md5
+  path: mlcommons_ssd_mobilenet_v1_warboy_1pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_ssd_mobilenet_v1_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_ssd_mobilenet_v1_warboy_2pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 8824e1d41f8454414e79712adba253bf
+  size: 17356401
+  hash: md5
+  path: mlcommons_ssd_mobilenet_v1_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_ssd_resnet34_warboy_1pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_ssd_resnet34_warboy_1pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: fe12a2b56d1ad06e5eca3644c39cf8b2
+  size: 24005454
+  hash: md5
+  path: mlcommons_ssd_resnet34_warboy_1pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_ssd_resnet34_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/mlcommons_ssd_resnet34_warboy_2pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: ea414d3cdadea731b5f7a30f3cec3dd0
+  size: 24830635
+  hash: md5
+  path: mlcommons_ssd_resnet34_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/yolov5l_warboy_1pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/yolov5l_warboy_1pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 852ae7e8055c2471eea2005acca04a9f
+  size: 54142786
+  hash: md5
+  path: yolov5l_warboy_1pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/yolov5l_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/yolov5l_warboy_2pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 6826074dd6d26ed4f74591a9eba1b1d3
+  size: 68725643
+  hash: md5
+  path: yolov5l_warboy_2pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/yolov5m_warboy_1pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/yolov5m_warboy_1pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 82c94731dc4ed9a37c7eba393ec5d32b
+  size: 35308825
+  hash: md5
+  path: yolov5m_warboy_1pe.enf

--- a/furiosa/models/data/generated/0.10.1_8b00177dc/yolov5m_warboy_2pe.enf.dvc
+++ b/furiosa/models/data/generated/0.10.1_8b00177dc/yolov5m_warboy_2pe.enf.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 2103136421c16a0807415f283f46b0da
+  size: 49493758
+  hash: md5
+  path: yolov5m_warboy_2pe.enf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ requires-python = "~=3.8"
 dynamic = ["version"]
 dependencies = [
     "furiosa-common == 0.10.*",
-    "furiosa-tools == 0.10.*",
     "furiosa-runtime == 0.10.*",
     "furiosa-native-postprocess == 0.9.0",
 


### PR DESCRIPTION
## 요약

As `furiosa-libcompiler` APT package & `furiosa-tools` Python package are deprecated,
use `furiosa-compiler` (same as `furiosa-compile`) CLI instead of `furiosa.tools.compiler.api.compile`

## 문제

현재 모델 주에서 돌릴 ENF 를 선택하는 기준은 사용자의 컴퓨터에 깔려있던 furiosa-libcompiler 버전과 매치되는 enf 를 찾는 것. 하지만 이는 runtime이 돌릴 수 있는 ir의 버전과 1:1로 매치되는 것이 아니기에 문제가 생길 수 있음. 또한, 이번 native-runtime 0.10.2 를 릴리즈 하면서 furiosa-libcompiler 는 릴리즈가 되지 않았기에 현재 native runtime과 1:1로 매치되는 enf를 만들어낼 수 없는 상태임.

## 해결 방법

모델 주가 돌릴 ENF를 찾는 방법을 libcompiler 대신 furiosa-compiler cli의 버전을 가져와서 찾도록 변경
enf_generator 를 변경하여 furiosa-libcompiler 대신 furiosa-compiler 를 사용하게 함

furiosa-compiler cli 의 backend version은 ir version이고 이 version이 breaking change를 판별할 수 있는 정보임

