### PR TITLE
Remove libgomp workaround, lint notebooks too

### DIFF
--- a/tekton/furiosa-models-ci/lint.yaml
+++ b/tekton/furiosa-models-ci/lint.yaml
@@ -14,7 +14,7 @@ spec:
         #!/usr/bin/env bash
         set -e
 
-        pip3 install --upgrade black isort ruff
+        pip3 install --upgrade black[jupyter] isort ruff
         make lint
 
       resources:

--- a/tekton/furiosa-models-ci/test.yaml
+++ b/tekton/furiosa-models-ci/test.yaml
@@ -34,9 +34,6 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -e
-
-        # FIXME: Remove me when TLS problem is solved (https://github.com/furiosa-ai/furiosa-sdk-private/issues/719)
-        export LD_PRELOAD=$(find $(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/torch/lib/ -name "libgomp*"):$LD_PRELOAD
         make unit_tests
         make notebook_tests
 
@@ -86,9 +83,6 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -e
-
-        # FIXME: Remove me when TLS problem is solved (https://github.com/furiosa-ai/furiosa-sdk-private/issues/719)
-        export LD_PRELOAD=$(find $(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/torch/lib/ -name "libgomp*"):$LD_PRELOAD
         make examples
 
       resources:

--- a/tekton/furiosa-models-regression-test/regression-test.yaml
+++ b/tekton/furiosa-models-regression-test/regression-test.yaml
@@ -85,10 +85,6 @@ spec:
         #!/usr/bin/env bash
         set -ex
         git config --global --add safe.directory /workspace/source
-
-        # FIXME: Remove me when TLS problem is solved (https://github.com/furiosa-ai/furiosa-sdk-private/issues/719)
-        export LD_PRELOAD=$(find $(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/torch/lib/ -name "libgomp*"):$LD_PRELOAD
-
         echo -n "## Pip freeze result for " > pip_freeze.txt
         echo $(params.modelName) >> pip_freeze.txt
         echo "<details><summary>pip freeze result</summary><pre>" >> pip_freeze.txt


### PR DESCRIPTION
## Changes

Remove libgomp workaround (was https://github.com/furiosa-ai/furiosa-sdk-private/issues/719)
Lint notebooks too

Already applied to tekton to test this change