### PR TITLE
Unify postprocess signatures

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.10.1 - TBU]
+
+### New Features
+- Addedd YOLOv7w6 Pose Estimation Model #173
+
+### Improvements
+- Detailed explanation about `with_scaling` argument #171
+- Added Jupyter Notebook examples #167
+- Use new furiosa-compiler CLI #174
+- Use IR version instead of compiler version when probing ENF files #174
+
+### Removed
+- furiosa-libcompiler APT package dependency #174
+
+### Bug fixes
+
 ## [0.10.0 - 2023-08-28]
 
 ### New Features
@@ -39,7 +55,7 @@
 - Remove Cpp postprocessor implementations #102
 - Change packaging tool from setuptools-rust to flit #109
 
-## Removed
+### Removed
 - Truncated models and corresponding postprocesses #144
 - **Breaking:** drop support of directly passing Model to session.create() #144
 

--- a/docs/examples/ssd_mobilenet.py
+++ b/docs/examples/ssd_mobilenet.py
@@ -7,4 +7,4 @@ mobilenet = SSDMobileNet()
 with create_runner(mobilenet.model_source()) as runner:
     inputs, contexts = mobilenet.preprocess(image)
     outputs = runner.run(inputs)
-    mobilenet.postprocess(outputs, contexts[0])
+    mobilenet.postprocess(outputs, contexts)

--- a/docs/examples/ssd_mobilenet_native.py
+++ b/docs/examples/ssd_mobilenet_native.py
@@ -8,4 +8,4 @@ mobilenet = SSDMobileNet(postprocessor_type=Platform.RUST)
 with create_runner(mobilenet.model_source()) as runner:
     inputs, contexts = mobilenet.preprocess(image)
     outputs = runner.run(inputs)
-    mobilenet.postprocess(outputs, contexts[0])
+    mobilenet.postprocess(outputs, contexts)

--- a/docs/examples/ssd_mobilenet_onnx.py
+++ b/docs/examples/ssd_mobilenet_onnx.py
@@ -23,4 +23,4 @@ with create_runner(quantized_onnx, compiler_config=compiler_config) as runner:
     # `with_scaling=True`.
     inputs, contexts = mobilenet.preprocess(image, with_scaling=True)
     outputs = runner.run(inputs)
-    mobilenet.postprocess(outputs, contexts[0])
+    mobilenet.postprocess(outputs, contexts)

--- a/docs/examples/ssd_resnet34_native.py
+++ b/docs/examples/ssd_resnet34_native.py
@@ -7,4 +7,4 @@ resnet34 = SSDResNet34(postprocessor_type=Platform.RUST)
 with create_runner(resnet34.model_source()) as runner:
     image, contexts = resnet34.preprocess(["tests/assets/cat.jpg"])
     output = runner.run(image)
-    resnet34.postprocessor(output, contexts=contexts[0])
+    resnet34.postprocessor(output, contexts=contexts)

--- a/docs/models/ssd_mobilenet.md
+++ b/docs/models/ssd_mobilenet.md
@@ -16,13 +16,13 @@ This model has been used since MLCommons v0.5.
         ```python
         --8<-- "docs/examples/ssd_mobilenet.py"
         ```
-     
+
     === "Native Postprocessor"
         ```python
         --8<-- "docs/examples/ssd_mobilenet_native.py"
         ```
 
-## Inputs 
+## Inputs
 The input is a 3-channel image of 300x300 (height, width).
 
 * Data Type: `numpy.float32`
@@ -56,15 +56,15 @@ You can refer to `postprocess()` function to learn how to decode boxes, classes,
 
 ## Pre/Postprocessing
 `furiosa.models.vision.SSDMobileNet` class provides `preprocess` and `postprocess` methods.
-`preprocess` method converts input images to input tensors, and `postprocess` method converts 
-model output tensors to a list of bounding boxes, scores and labels. 
+`preprocess` method converts input images to input tensors, and `postprocess` method converts
+model output tensors to a list of bounding boxes, scores and labels.
 You can find examples at [SSDMobileNet Usage](#SSDMobileNet_Usage).
- 
+
 ### `furiosa.models.vision.SSDMobileNet.preprocess`
 ::: furiosa.models.vision.ssd_mobilenet.SSDMobileNetPreProcessor.__call__
     options:
         show_source: false
-    
+
 ### `furiosa.models.vision.SSDMobileNet.postprocess`
 ::: furiosa.models.vision.ssd_mobilenet.SSDMobileNetPythonPostProcessor.__call__
     options:

--- a/furiosa/models/client/main.py
+++ b/furiosa/models/client/main.py
@@ -137,6 +137,9 @@ def main():
         if verbose:
             logging.root.setLevel(logging.DEBUG)
         input_paths = resolve_input_paths(Path(_input_paths))
+        if len(input_paths) == 0:
+            logger.warning(f"No input files found in '{_input_paths}'")
+            sys.exit(1)
         logger.debug(f"Collected input paths: {input_paths}")
         model_cls = get_model_or_exit(model_name)
         api.run_inferences(model_cls, input_paths, postprocess)

--- a/furiosa/models/client/main.py
+++ b/furiosa/models/client/main.py
@@ -9,7 +9,7 @@ import yaml
 
 from . import api
 from .. import __version__ as models_version
-from ..types import ImageClassificationModel, Model, ObjectDetectionModel
+from ..types import ImageClassificationModel, Model, ObjectDetectionModel, PoseEstimationModel
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ def parse_args() -> argparse.Namespace:
 
     list_parser = subparsers.add_parser("list", help="Lists available models")
     list_parser.add_argument(
-        "-t", "--type", type=str, help="Limits the task type (ex. classify, detect)"
+        "-t", "--type", type=str, help="Limits the task type (ex. classify, detect, pose)"
     )
 
     desc_parser = subparsers.add_parser("desc", help="Prints out a description of a model")
@@ -92,6 +92,8 @@ def get_filter(filter_type: Optional[str]) -> Callable[..., bool]:
         return lambda x: issubclass(x, ObjectDetectionModel)
     elif "classif" in filter_type.lower():
         return lambda x: issubclass(x, ImageClassificationModel)
+    elif "pose" in filter_type.lower():
+        return lambda x: issubclass(x, PoseEstimationModel)
     else:
         logger.warning(f"Unknown type filter '{filter_type}', showing all models...")
         return lambda _: True

--- a/furiosa/models/data/enf_generator.py
+++ b/furiosa/models/data/enf_generator.py
@@ -85,6 +85,7 @@ def quantize_and_compile_model(arg: Tuple[int, Path, int]):
             f'furiosa-compiler --target-npu {target_npu} --output {enf_path} '
             f'{quantized_onnx_file.name}'
         )
+        print(f"  [{index}] {model_short_name} compile start")
         sp.run(
             shlex.split(cmd),
             env={"NPU_COMPILER_CONFIG_PATH": compiler_config_path},

--- a/furiosa/models/vision/resnet50/__init__.py
+++ b/furiosa/models/vision/resnet50/__init__.py
@@ -62,18 +62,17 @@ class ResNet50PreProcessor(PreProcessor):
 
 
 class ResNet50PostProcessor(PythonPostProcessor):
-    """Convert the outputs of a model to a label string, such as car and cat.
-
-    Args:
-        model_outputs: the outputs of the model.
-            Please learn more about the output of model,
-            please refer to [Outputs](resnet50_v1.5.md#outputs).
-
-    Returns:
-        str: A classified label, e.g., "tabby, tabby cat".
-    """
-
     def __call__(self, model_outputs: Sequence[npt.ArrayLike], contexts: Any = None) -> str:
+        """Convert the outputs of a model to a label string, such as car and cat.
+
+        Args:
+            model_outputs: the outputs of the model.
+                Please learn more about the output of model,
+                please refer to [Outputs](resnet50_v1.5.md#outputs).
+
+        Returns:
+            str: A classified label, e.g., "tabby, tabby cat".
+        """
         return CLASSES[int(model_outputs[0]) - 1]
 
 

--- a/furiosa/models/vision/ssd_resnet34/__init__.py
+++ b/furiosa/models/vision/ssd_resnet34/__init__.py
@@ -397,30 +397,64 @@ class SSDResNet34NativePostProcessor(RustPostProcessor):
     def __init__(self):
         self._native = native.ssd_resnet34.RustPostProcessor()
 
-    def __call__(self, model_outputs: Sequence[numpy.ndarray], contexts: Sequence[Dict[str, Any]]):
-        raw_results = self._native.eval(
-            [np.squeeze(s, axis=0) for s in model_outputs[6:]],
-            [np.squeeze(s, axis=0) for s in model_outputs[:6]],
-        )
+    def __call__(
+        self, model_outputs: Sequence[numpy.ndarray], contexts: Sequence[Dict[str, Any]]
+    ) -> List[List[ObjectDetectionResult]]:
+        """Convert the outputs of this model to a list of bounding boxes, scores and labels
 
-        results = []
-        width = contexts['width']
-        height = contexts['height']
-        for value in raw_results:
-            left = value.left * width
-            right = value.right * width
-            top = value.top * height
-            bottom = value.bottom * height
-            results.append(
-                ObjectDetectionResult(
-                    index=value.class_id,
-                    label=CLASSES[value.class_id],
-                    score=value.score,
-                    boundingbox=LtrbBoundingBox(left=left, top=top, right=right, bottom=bottom),
-                )
+        Args:
+            model_outputs: the outputs of the model. To learn more about the output of model,
+                please refer to [Outputs](ssd_resnet34.md#outputs).
+            contexts: context coming from `preprocess()`
+
+        Returns:
+            Detected Bounding Box and its score and label represented as
+                `ObjectDetectionResult`.
+                To learn more about `ObjectDetectionResult`, 'Definition of ObjectDetectionResult'
+                can be found below.
+
+        Definition of ObjectDetectionResult and LtrbBoundingBox:
+            ::: furiosa.models.vision.postprocess.LtrbBoundingBox
+                options:
+                    show_source: true
+            ::: furiosa.models.vision.postprocess.ObjectDetectionResult
+                options:
+                    show_source: true
+        """
+        if len(model_outputs) == 0:
+            return [[]]
+        batch_size = model_outputs[0].shape[0]
+        assert batch_size == len(
+            contexts
+        ), "batch size of model_outputs and len(contexts) must be same"
+
+        all_results = []
+
+        for i, context in enumerate(contexts):
+            raw_results = self._native.eval(
+                [s[i, :] for s in model_outputs[6:]],
+                [s[i, :] for s in model_outputs[:6]],
             )
 
-        return results
+            results = []
+            width = context['width']
+            height = context['height']
+            for value in raw_results:
+                left = value.left * width
+                right = value.right * width
+                top = value.top * height
+                bottom = value.bottom * height
+                results.append(
+                    ObjectDetectionResult(
+                        index=value.class_id,
+                        label=CLASSES[value.class_id],
+                        score=value.score,
+                        boundingbox=LtrbBoundingBox(left=left, top=top, right=right, bottom=bottom),
+                    )
+                )
+            all_results.append(results)
+
+        return all_results
 
 
 class SSDResNet34(ObjectDetectionModel):

--- a/tests/bench/test_ssd_mobilenet.py
+++ b/tests/bench/test_ssd_mobilenet.py
@@ -93,7 +93,8 @@ def test_mlcommons_ssd_mobilenet_with_native_rust_pp_accuracy(benchmark):
     def workload(image_id, image):
         image, contexts = model.preprocess([image])
         outputs = runner.run(image)
-        result = model.postprocess(outputs, contexts[0])
+        batch_result = model.postprocess(outputs, contexts)
+        result = np.squeeze(batch_result, axis=0)  # squeeze the batch axis
 
         for res in result:
             detection = {

--- a/tests/bench/test_ssd_resnet34.py
+++ b/tests/bench/test_ssd_resnet34.py
@@ -109,7 +109,8 @@ def test_mlcommons_ssd_resnet34_with_native_rust_pp_accuracy(benchmark):
     def workload(image_id, image):
         image, contexts = model.preprocess([image])
         outputs = runner.run(image)
-        result = model.postprocess(outputs, contexts[0])
+        batch_result = model.postprocess(outputs, contexts)
+        result = np.squeeze(batch_result, axis=0)  # squeeze the batch axis
 
         for res in result:
             detection = {


### PR DESCRIPTION
Some native postprocesses can only take one context at a time.
https://github.com/furiosa-ai/furiosa-models/blob/main/furiosa/models/client/api.py#L113-L116

Related TODOs, FIXMEs
- https://github.com/furiosa-ai/furiosa-models/blob/75199f782dfa48dcc404c6e0393968df3eca038f/furiosa/models/client/api.py#L113
- https://github.com/furiosa-ai/furiosa-models/blob/75199f782dfa48dcc404c6e0393968df3eca038f/furiosa/models/vision/ssd_mobilenet/__init__.py#L290

Others should take a sequence of contexts. So unify the signature 