### PR TITLE
Add APT deps guide & extra package explanations

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,32 +1,46 @@
 # Getting Started
+
 This documentation explains how to install furiosa-models, how to use available models in furiosa-models, and
 how to explore the documents.
 
 ## Prerequisites
-`furiosa-models` can be installed on various Linux distributions, but it has been tested on the followings:
 
-* CentOS 7 or higher
-* Debian bullseye or higher
-* Ubuntu 20.04 or higher
+`furiosa-models` is compatible with various Linux distributions, and it has been tested on the following:
 
-The following packages should be installed, but the followings are installed by default in most systems.
-So, only when you have any dependency issue, you need to install the following packages:
+- CentOS 7 or higher
+- Debian bullseye or higher
+- Ubuntu 20.04 or higher
 
-* libstdc++6
-* libgomp
+Ensure that the following packages are installed. In most systems, these are installed by default.
+However, if you encounter any dependency issues, manually install the following:
+
+- libstdc++6
+- libgomp
 
 ## Installing
+
+### APT Dependencies
+
+To install the APT dependencies, you need to set up authentication through [FuriosaAI IAM](https://iam.furiosa.ai).
+After authentication, install the following packages:
+
+```shell
+sudo apt-get update && sudo apt-get install furiosa-libhal-warboy furiosa-compiler
+```
+
+### Installing the `furiosa-models` package
+
 You can quickly install Furiosa Models by using `pip` as following:
 
-```sh
+```shell
 pip install --upgrade pip setuptools wheel
 pip install 'furiosa-models'
 ```
 
 !!!Info
-    Older versions of wheel may reject the native-build wheels of furiosa-models.
+    Older versions of wheel may reject the native-build wheels of `furiosa-models`.
     Please make sure of installing & upgrading Python packaging tools before
-    installing furiosa-models.
+    installing `furiosa-models`.
 
 
 ??? "Building from Source Code (click to see)"
@@ -36,6 +50,23 @@ pip install 'furiosa-models'
     git clone https://github.com/furiosa-ai/furiosa-models
     pip install ./furiosa-models
     ```
+
+### Extra packages
+
+To enable the use of the `furiosa models serve` command, you need to install the `furiosa-serving` Python package.
+You can achieve this by specifying the serving extra package when installing `furiosa-models`.
+
+```shell
+pip install 'furiosa-models[serving]`
+```
+
+If you require additional packages related to compilation, you can install the full extra package, which includes all relevant dependencies.
+
+```shell
+pip install 'furiosa-models[full]`
+```
+
+These commands ensure that you have the necessary packages for serving models with furiosa-serving or any other compiling-related functionalities provided by the full extra package.
 
 ## Quick example and Guides
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -57,13 +57,13 @@ To enable the use of the `furiosa models serve` command, you need to install the
 You can achieve this by specifying the serving extra package when installing `furiosa-models`.
 
 ```shell
-pip install 'furiosa-models[serving]`
+pip install 'furiosa-models[serving]'
 ```
 
 If you require additional packages related to compilation, you can install the full extra package, which includes all relevant dependencies.
 
 ```shell
-pip install 'furiosa-models[full]`
+pip install 'furiosa-models[full]'
 ```
 
 These commands ensure that you have the necessary packages for serving models with furiosa-serving or any other compiling-related functionalities provided by the full extra package.


### PR DESCRIPTION
[Updated document](https://furiosa-ai.github.io/furiosa-models/PR-183/getting_started/)
APT 의존성 설치와 python extra package 에 대한 설명을 추가했습니다.