### PR TITLE
Ensure Backward Compatibility by Checking FURIOSA_DEVICES & NPU_DEVNAME

### DIFF
--- a/furiosa/models/cli/api.py
+++ b/furiosa/models/cli/api.py
@@ -1,4 +1,5 @@
 from functools import reduce
+import os
 from time import perf_counter
 from typing import Any, Callable, List, Optional, Sequence, Type
 
@@ -124,6 +125,9 @@ def get_pe_count_from_device_str(device_str: Optional[str]) -> int:
     Returns:
         Number of PEs
     """
+    device_str = device_str or os.environ.get(
+        "FURIOSA_DEVICES", os.environ.get("NPU_DEVNAME", None)
+    )
     if device_str:
         device_mode = get_device_mode(device_str)
         return device_file_to_pe_count(device_mode)


### PR DESCRIPTION
## Pull Request Description:

In this pull request, address backward compatibility by checking the environment variables `FURIOSA_DEVICES` and `NPU_DEVNAME` in addition to the provided device string in the `get_pe_count_from_device_str` function of `furiosa/models/cli/api.py`. This adjustment allows for seamless support of older configurations and ensures a smooth transition for users who may still rely on these environment variables.

## Changes:

Modified the `get_pe_count_from_device_str` function to consider the `FURIOSA_DEVICES` and `NPU_DEVNAME` environment variables if no device string is provided explicitly.
This modification enhances the backward compatibility of the codebase, ensuring that users relying on the older environment variable configurations continue to experience consistent behavior.
