### PR TITLE
Apply patches from release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,23 @@ for FuriosaAI NPU. However, all models are standard ONNX or tflite models,
 and they can run even on CPU and GPU as well.
 
 ## Releases
+* [v0.10.2](https://furiosa-ai.github.io/furiosa-models/v0.10.2/changelog/) - 2024-05-29
+* [v0.10.1](https://furiosa-ai.github.io/furiosa-models/v0.10.1/changelog/) - 2023-11-25
 * [v0.10.0](https://furiosa-ai.github.io/furiosa-models/v0.10.0/changelog/) - 2023-08-28
 * [v0.9.1](https://furiosa-ai.github.io/furiosa-models/v0.9.1/changelog/) - 2023-05-26
 * [v0.9.0](https://furiosa-ai.github.io/furiosa-models/v0.9.0/changelog/) - 2023-05-12
 * [v0.8.0](https://furiosa-ai.github.io/furiosa-models/v0.8.0/changelog/) - 2022-11-10
 
 ## Online Documentation
-If you are new, you can start from [Getting Started](https://furiosa-ai.github.io/furiosa-models/v0.10.0/getting_started/).
+If you are new, you can start from [Getting Started](https://furiosa-ai.github.io/furiosa-models/latest/getting_started/).
 You can also find the latest online documents,
 including programming guides, API references, and examples from the following:
 
 * [Furiosa Models - Latest Documentation](https://furiosa-ai.github.io/furiosa-models/latest/)
-* [Model Object](https://furiosa-ai.github.io/furiosa-models/v0.10.0/model_object/)
-* [Model List](https://furiosa-ai.github.io/furiosa-models/v0.10.0/#model_list)
-* [Command Line Tool](https://furiosa-ai.github.io/furiosa-models/v0.10.0/command_line_tool/)
-* [Furiosa SDK - Tutorial and Code Examples](https://furiosa-ai.github.io/docs/v0.10.0/en/software/tutorials.html)
+* [Model Object](https://furiosa-ai.github.io/furiosa-models/latest/model_object/)
+* [Model List](https://furiosa-ai.github.io/furiosa-models/latest/#model_list)
+* [Command Line Tool](https://furiosa-ai.github.io/furiosa-models/latest/command_line_tool/)
+* [Furiosa SDK - Tutorial and Code Examples](https://furiosa-ai.github.io/docs/latest/en/software/tutorials.html)
 
 
 ## <a name="model_list"></a>Model List
@@ -32,14 +34,14 @@ you can find details about loading a model, their input and output tensors, pre/
 
 | Model                                                                                             | Task                 | Size | Accuracy                  |
 | ------------------------------------------------------------------------------------------------- | -------------------- | ---- | ------------------------- |
-| [ResNet50](https://furiosa-ai.github.io/furiosa-models/v0.10.0/models/resnet50_v1.5/)             | Image Classification | 25M  | 75.618% (ImageNet1K-val)  |
-| [EfficientNetB0](https://furiosa-ai.github.io/furiosa-models/v0.10.0/models/efficientnet_b0/)     | Image Classification | 6.4M | 72.44% (ImageNet1K-val)   |
-| [EfficientNetV2-S](https://furiosa-ai.github.io/furiosa-models/v0.10.0/models/efficientnet_v2_s/) | Image Classification | 26M  | 83.532% (ImageNet1K-val)  |
-| [SSDMobileNet](https://furiosa-ai.github.io/furiosa-models/v0.10.0/models/ssd_mobilenet/)         | Object Detection     | 7.2M | mAP 0.232 (COCO 2017-val) |
-| [SSDResNet34](https://furiosa-ai.github.io/furiosa-models/v0.10.0/models/ssd_resnet34/)           | Object Detection     | 20M  | mAP 0.220 (COCO 2017-val) |
-| [YOLOv5M](https://furiosa-ai.github.io/furiosa-models/v0.10.0/models/yolov5m/)                    | Object Detection     | 21M  | mAP 0.272 (Bdd100k-val) <sup>[[1]](#footnote_1)</sup> |
-| [YOLOv5L](https://furiosa-ai.github.io/furiosa-models/v0.10.0/models/yolov5l/)                    | Object Detection     | 46M  | mAP 0.284 (Bdd100k-val) <sup>[[1]](#footnote_1)</sup> |
-| [YOLOv7w6Pose](https://furiosa-ai.github.io/furiosa-models/PR-173/models/yolov7_w6_pose/)         | Pose Estimation      | 80M  | N/A                       |
+| [ResNet50](https://furiosa-ai.github.io/furiosa-models/latest/models/resnet50_v1.5/)             | Image Classification | 25M  | 75.618% (ImageNet1K-val)  |
+| [EfficientNetB0](https://furiosa-ai.github.io/furiosa-models/latest/models/efficientnet_b0/)     | Image Classification | 6.4M | 72.44% (ImageNet1K-val)   |
+| [EfficientNetV2-S](https://furiosa-ai.github.io/furiosa-models/latest/models/efficientnet_v2_s/) | Image Classification | 26M  | 83.532% (ImageNet1K-val)  |
+| [SSDMobileNet](https://furiosa-ai.github.io/furiosa-models/latest/models/ssd_mobilenet/)         | Object Detection     | 7.2M | mAP 0.232 (COCO 2017-val) |
+| [SSDResNet34](https://furiosa-ai.github.io/furiosa-models/latest/models/ssd_resnet34/)           | Object Detection     | 20M  | mAP 0.220 (COCO 2017-val) |
+| [YOLOv5M](https://furiosa-ai.github.io/furiosa-models/latest/models/yolov5m/)                    | Object Detection     | 21M  | mAP 0.272 (Bdd100k-val) <sup>[[1]](#footnote_1)</sup> |
+| [YOLOv5L](https://furiosa-ai.github.io/furiosa-models/latest/models/yolov5l/)                    | Object Detection     | 46M  | mAP 0.284 (Bdd100k-val) <sup>[[1]](#footnote_1)</sup> |
+| [YOLOv7w6Pose](https://furiosa-ai.github.io/furiosa-models/latest/models/yolov7_w6_pose/)        | Pose Estimation      | 80M  | N/A                       |
 
 _<a name="footnote_1">[1]</a>: The accuracy of the yolov5 f32 model trained with bdd100k-val dataset, is mAP 0.295 (for yolov5m) and mAP 0.316 (for yolov5l)._
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,15 +1,31 @@
 # Changelog
 
-## [0.10.1 - TBU]
+## [0.10.2 - 2024-05-29]
 
 ### New Features
-- Addedd YOLOv7w6 Pose Estimation Model #173
+
+### Improvements
+- Added YOLOv5 Python postprocess #185
+- Added parameter in YOLO postprocess to perform sigmoid or not #185
+
+### Removed
+
+### Bug fixes
+- Add missing `requests` dependency #187
+
+## [0.10.1 - 2023-11-25]
+
+### New Features
+- Added YOLOv7w6 Pose Estimation Model #173
+- Added `serve` subcommand to open REST server #182
 
 ### Improvements
 - Detailed explanation about `with_scaling` argument #171
 - Added Jupyter Notebook examples #167
 - Use new furiosa-compiler CLI #174
 - Use IR version instead of compiler version when probing ENF files #174
+- Unify postprocess signatures #180
+- Use Typer CLI library instead of argparse #181
 
 ### Removed
 - furiosa-libcompiler APT package dependency #174

--- a/docs/models/yolov5l.md
+++ b/docs/models/yolov5l.md
@@ -55,6 +55,13 @@ You can find examples at [YOLOv5l Usage](#YOLOv5l_Usage).
         show_source: false
 
 ### `furiosa.models.vision.YOLOv5l.postprocess`
-::: furiosa.models.vision.yolov5.core.YOLOv5PythonPostProcessor.__call__
+::: furiosa.models.vision.yolov5.core.YOLOv5NativePostProcessor.__call__
     options:
         show_source: false
+
+### Python Postprocessor
+
+This class offers two types of postprocessing implementations: Python and Rust.
+
+To use the Python postprocessing implementation, pass the parameter
+`postprocessor_type=Platform.PYTHON` when calling the model.

--- a/docs/models/yolov5m.md
+++ b/docs/models/yolov5m.md
@@ -54,7 +54,13 @@ You can find examples at [YOLOv5m Usage](#YOLOv5m_Usage).
         show_source: false
 
 ### `furiosa.models.vision.YOLOv5m.postprocess`
-::: furiosa.models.vision.yolov5.core.YOLOv5PythonPostProcessor.__call__
+::: furiosa.models.vision.yolov5.core.YOLOv5NativePostProcessor.__call__
     options:
         show_source: false
 
+### Python Postprocessor
+
+This class offers two types of postprocessing implementations: Python and Rust.
+
+To use the Python postprocessing implementation, pass the parameter
+`postprocessor_type=Platform.PYTHON` when calling the model.

--- a/docs/tutorials/navigate_models.ipynb
+++ b/docs/tutorials/navigate_models.ipynb
@@ -59,8 +59,8 @@
     "|    ResNet50     |   MLCommons ResNet50 model      | Image Classification |         Python          |\n",
     "|  SSDMobileNet   | MLCommons MobileNet v1 model    |   Object Detection   |      Python, Rust       |\n",
     "|   SSDResNet34   | MLCommons SSD ResNet34 model    |   Object Detection   |      Python, Rust       |\n",
-    "|     YOLOv5l     |      YOLOv5 Large model         |   Object Detection   |          Rust           |\n",
-    "|     YOLOv5m     |     YOLOv5 Medium model         |   Object Detection   |          Rust           |\n",
+    "|     YOLOv5l     |      YOLOv5 Large model         |   Object Detection   |      Python, Rust       |\n",
+    "|     YOLOv5m     |     YOLOv5 Medium model         |   Object Detection   |      Python, Rust       |\n",
     "| EfficientNetB0  |    EfficientNet B0 model        | Image Classification |         Python          |\n",
     "| EfficientNetV2s |    EfficientNetV2-s model       | Image Classification |         Python          |\n",
     "| EfficientNetV2s |    EfficientNetV2-s model       | Image Classification |         Python          |\n",
@@ -154,13 +154,6 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      ":-) Finished in 0.000006756s\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -198,7 +191,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.10.12"
   },
   "orig_nbformat": 4
  },

--- a/furiosa/models/__init__.py
+++ b/furiosa/models/__init__.py
@@ -2,5 +2,5 @@
 
 from . import errors, vision
 
-__version__ = "0.10.0.dev0"
+__version__ = "0.11.0.dev0"
 __all__ = ["errors", "vision"]

--- a/furiosa/models/vision/ssd_mobilenet/__init__.py
+++ b/furiosa/models/vision/ssd_mobilenet/__init__.py
@@ -271,9 +271,9 @@ class SSDMobileNetPythonPostProcessor(PythonPostProcessor):
                 bb_list = box.tolist()
                 predicted_result.append(
                     ObjectDetectionResult(
-                        index=label,
+                        index=label.item(),
                         label=CLASSES[label],
-                        score=score,
+                        score=score.item(),
                         boundingbox=LtrbBoundingBox(
                             left=bb_list[0], top=bb_list[1], right=bb_list[2], bottom=bb_list[3]
                         ),

--- a/furiosa/models/vision/yolov5/core.py
+++ b/furiosa/models/vision/yolov5/core.py
@@ -231,7 +231,7 @@ class YOLOv5NativePostProcessor(RustPostProcessor):
                     ObjectDetectionResult(
                         index=class_id,
                         label=self.class_names[class_id],
-                        score=score,
+                        score=score.item(),
                         boundingbox=LtrbBoundingBox(
                             left=(left - padw) / scale,
                             top=(top - padh) / scale,

--- a/furiosa/models/vision/yolov5/postprocess.py
+++ b/furiosa/models/vision/yolov5/postprocess.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, List, Sequence
 
 import numpy as np
 import torch
@@ -38,7 +38,7 @@ class YOLOv5PythonPostProcessor(PythonPostProcessor):
         conf_thres: float = 0.25,
         iou_thres: float = 0.45,
         with_sigmoid: bool = False,
-    ):
+    ) -> List[List[ObjectDetectionResult]]:
         """Convert the outputs of this model to a list of bounding boxes, scores and labels
 
         Args:
@@ -108,7 +108,7 @@ class YOLOv5PythonPostProcessor(PythonPostProcessor):
                     ObjectDetectionResult(
                         index=class_id,
                         label=self.class_names[class_id],
-                        score=score,
+                        score=score.item(),
                         boundingbox=LtrbBoundingBox(
                             left=(left - padw) / scale,
                             top=(top - padh) / scale,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,10 @@ dependencies = [
     "requests",
     "tabulate",
     "torch",
+    "torchvision",
     "typer",
+    # https://github.com/open-telemetry/opentelemetry-python/issues/2717
+    "protobuf ~= 3.20",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Also bump version up to 0.11.0dev0
- 몇몇 object detection model 의 output이 python internal float 자료형이 아니라 numpy.float 인것을 확인해서 python 내장 float 이 되도록 바꿨습니다.
  - 바꾸지 않으면 `furiosa-models serve` 에서 json 으로 직렬화 하지 못해서 에러남 